### PR TITLE
Add a readOnly field to Archiver class

### DIFF
--- a/proteus/Archiver.py
+++ b/proteus/Archiver.py
@@ -41,6 +41,7 @@ class AR_base:
         self.comm=comm
         self.rank = comm.rank()
         self.size = comm.size()
+        self.readOnly = readOnly
         import datetime
         #filename += datetime.datetime.now().isoformat()
         try:
@@ -117,10 +118,12 @@ class AR_base:
         self.xmlFile.truncate()
     def close(self):
         log("Closing Archive")
-        self.clear_xml()
-        self.xmlFile.write(self.xmlHeader)
+        if not self.readOnly:
+            self.clear_xml()
+            self.xmlFile.write(self.xmlHeader)
         indentXML(self.tree.getroot())
-        self.tree.write(self.xmlFile)
+        if not self.readOnly:
+            self.tree.write(self.xmlFile)
         self.xmlFile.close()
         if self.hdfFile != None:
             self.hdfFile.close()


### PR DESCRIPTION
And use in several if statements.

I had a problem with archive.cloes() function.

```python
    u = read_from_hdf5(archive.hdfFile, label_base.format("u", M - 1))
    archive.close()
```
would complain about archive being not opened for write. On closer inspection it turned out that whether I am openinig my xdmf for write or read it alwyas tries to perform some reformatting of xml etc.

I had to close the archive manaully from the code. Waiting for the program to finish would create to many opened files and crash my post-processing of Monte Carlo results.