### PR TITLE
took out hard-wired  recipients

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -28,5 +28,7 @@ commit_container: erdccm/proteus
 
 notifications:
     email:
-        - cekees@gmail.com
+        on_success: change
+	on_failure: always
+
 


### PR DESCRIPTION
I believe this should start emailing the committer  on failed builds.