### PR TITLE
got rid  of paths--user should set add proteus/scripts dirs with gmsh and tetgen

### DIFF
--- a/scripts/generate_gmsh_mesh
+++ b/scripts/generate_gmsh_mesh
@@ -28,11 +28,11 @@ if [ -f gmsh.mesh ]; then
   echo =============================
   grep ille gmsh.log | grep -v no
 
-  $PROTEUS/scripts/gmsh2tetgen gmsh.mesh 
+  gmsh2tetgen gmsh.mesh 
   cp mesh.vtk ../$dir.vtk
   echo =============================
   ls -lhatr mesh.*
-  $PROTEUS_PREFIX/bin/tetgen -en mesh.ele
+  tetgen -en mesh.ele
   echo =============================
   ls -lhatr mesh.*
   mv mesh.1.ele mesh.ele

--- a/scripts/generate_gmsh_mesh2
+++ b/scripts/generate_gmsh_mesh2
@@ -28,11 +28,11 @@ if [ -f gmsh.mesh ]; then
   echo =============================
   grep ille gmsh.log | grep -v no
 
-  $PROTEUS/proteusModule/scripts/gmsh2tetgen gmsh.mesh 
+  gmsh2tetgen gmsh.mesh 
   cp mesh.vtk ../$dir.vtk
   echo =============================
   ls -lhatr mesh.*
-  $PROTEUS_PREFIX/bin/tetgen -Ven mesh.ele
+  tetgen -Ven mesh.ele
   echo =============================
   ls -lhatr mesh.*
   mv mesh.1.ele mesh.ele


### PR DESCRIPTION
We can clean this up when we have our MeshTools sprint. I doubt there's a strong reason to keep around the fortran conversion scripts, and the Python scripts needs some work as well as just installing them with the rest of proteus or having gmsh work naturally with a GmshDomain type like the PiecewiseLinearComplexDomain that works with tetgen. 