### PR TITLE
load lapack,blas headers from Accelerate.h

### DIFF
--- a/proteus/config/default.py
+++ b/proteus/config/default.py
@@ -20,8 +20,8 @@ platform_lapack_integer = None
 if sys.platform == 'darwin':
     platform_extra_link_args = ['-framework', 'Accelerate']
     platform_lapack_integer = '__CLPK_integer'
-    platform_blas_h = r'<veclib/cblas.h>'
-    platform_lapack_h = r'<veclib/clapack.h>'
+    platform_blas_h = r'<Accelerate/Accelerate.h>'
+    platform_lapack_h = r'<Accelerate/Accelerate.h>'
 elif sys.platform == 'linux2':
     platform_extra_compile_args = ['-DPETSC_INCLUDE_AS_C']
     platform_extra_link_args = ['-Wl,-rpath,' + PROTEUS_LIB_DIR]


### PR DESCRIPTION
vecLib/clapack.h doesn't work on OS X 10.10, and I think has been deprecated for some time.

I'm not sure for how many versions Accelerate.h works here, but I think it's at least a few.

This was the only patch I needed for proteus to build on 10.10.