### PR TITLE
add new flux HamiltonJacobi_Advection_pN_DiagonalLesaintRaviart_Diffu…

### DIFF
--- a/proteus/NumericalFlux.py
+++ b/proteus/NumericalFlux.py
@@ -3372,6 +3372,7 @@ class HamiltonJacobi_DiagonalLesaintRaviart_Diffusion_IIPG(NF_base):
                         #                                                                    self.penalty_floor)
 
 class HamiltonJacobi_DiagonalLesaintRaviart_Diffusion_SIPG_exterior(Diffusion_SIPG_exterior):
+    useStrongDirichletConstraints=False
     def __init__(self,vt,getPointwiseBoundaryConditions,
                  getAdvectiveFluxBoundaryConditions,
                  getDiffusiveFluxBoundaryConditions,
@@ -3504,6 +3505,154 @@ class HamiltonJacobi_DiagonalLesaintRaviart_Diffusion_SIPG_exterior(Diffusion_SI
                                                                                                 fluxJacobian_exterior[ci][cj],
                                                                                                 self.scale_penalty,
                                                                                                 self.penalty_floor)
+
+class HamiltonJacobi_Advection_pN_DiagonalLesaintRaviart_Diffusion_SIPG_exterior(Diffusion_SIPG_exterior):
+    useStrongDirichletConstraints=False
+    def __init__(self,vt,getPointwiseBoundaryConditions,
+                 getAdvectiveFluxBoundaryConditions,
+                 getDiffusiveFluxBoundaryConditions,
+                 getPeriodicBoundaryConditions=None,
+                 speedEvaluationType=1):
+        Diffusion_SIPG_exterior.__init__(self,vt,getPointwiseBoundaryConditions,
+                 getAdvectiveFluxBoundaryConditions,
+                 getDiffusiveFluxBoundaryConditions,
+                 getPeriodicBoundaryConditions)
+        self.speedEvaluationType = int(speedEvaluationType)#1 -- use max, otherwise allow disc.
+        for ci in range(self.nc):
+            self.advectiveNumericalFlux[ci] = False
+            self.diffusiveNumericalFlux[ci] = True
+            self.HamiltonJacobiNumericalFlux[ci] = True
+        self.scale_penalty = 1; self.penalty_floor = 0.0
+    def calculateExteriorNumericalFlux(self,inflowFlag,q,ebqe):
+        for ci in range(self.nc):
+            self.ebqe[('u',ci)].flat[:] = ebqe[('u',ci)].flat[:]
+            for (ebNE,k),g,x in zip(self.DOFBoundaryConditionsDictList[ci].keys(),
+                                    self.DOFBoundaryConditionsDictList[ci].values(),
+                                    self.DOFBoundaryPointDictList[ci].values()):
+                self.ebqe[('u',ci)][ebNE,k]=g(x,self.vt.timeIntegration.t)
+        for ci in range(self.nc):
+            for bci in self.periodicBoundaryConditionsDictList[ci].values():
+                self.ebqe[('u',ci)][bci[0]]=ebqe[('u',ci)][bci[1]]
+                self.ebqe[('u',ci)][bci[1]]=ebqe[('u',ci)][bci[0]]
+        self.vt.coefficients.evaluate(self.vt.timeIntegration.t,self.ebqe)
+        if self.vt.movingDomain:
+            self.vt.coefficients.updateToMovingDomain(self.vt.timeIntegration.t,self.ebqe)
+        for ci in range(self.nc):
+            cnumericalFlux.calculateExteriorLesaintRaviartNumericalFlux(self.speedEvaluationType,
+                                                                        self.mesh.exteriorElementBoundariesArray,
+                                                                        self.mesh.elementBoundaryElementsArray,
+                                                                        self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                        self.isDOFBoundary[ci],
+                                                                        inflowFlag[ci],
+                                                                        ebqe['n'],
+                                                                        self.ebqe[('u',ci)],
+                                                                        self.ebqe[('H',ci)],
+                                                                        self.ebqe[('dH',ci,ci)],
+                                                                        ebqe[('u',ci)],
+                                                                        ebqe[('H',ci)],
+                                                                        ebqe[('dH',ci,ci)],
+                                                                        ebqe[('HamiltonJacobiFlux',ci)],
+                                                                        ebqe[('dHamiltonJacobiFlux_left',ci,ci)])
+
+            # we add the term that technically should be an advective flux but since
+            # it is constant wrt variables here, we just add it to the HamiltonJacobiFlux
+            #  < div(p I), w> = < -p I, grad w > + <pI n, grad w>_{\partial\Lambda}
+            #
+            # so our term is  pIn = p \n  and since 'f' = pI, we just innerproduct
+            # with 'n' to get our term.
+            ebqe[('HamiltonJacobiFlux',ci)][:] += (ebqe[('f',ci)]*ebqe['n']).sum(-1)   #  + p N from advection terms
+            ebqe[('dHamiltonJacobiFlux_left',ci,ci)][:] += 0.0
+
+
+            for ck in range(self.nc):
+                if ebqe.has_key(('a',ci,ck)):
+                    if self.vt.sd:
+                        cnumericalFlux.calculateExteriorNumericalDiffusiveFlux_sd(self.vt.coefficients.sdInfo[(ci,ck)][0],self.vt.coefficients.sdInfo[(ci,ck)][0],
+                                                                                  self.mesh.exteriorElementBoundariesArray,
+                                                                                  self.mesh.elementBoundaryElementsArray,
+                                                                                  self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                                  self.isDOFBoundary[ck],
+                                                                                  ebqe['n'],
+                                                                                  self.ebqe[('a',ci,ck)],
+                                                                                  self.ebqe[('grad(phi)',ck)],
+                                                                                  self.ebqe[('u',ck)],
+                                                                                  ebqe[('a',ci,ck)],
+                                                                                  ebqe[('grad(phi)',ck)],
+                                                                                  ebqe[('u',ck)],
+                                                                                  ebqe[('penalty')],
+                                                                                  ebqe[('diffusiveFlux',ck,ci)],
+                                                                                  self.scale_penalty,
+                                                                                  self.penalty_floor)
+                    else:
+                        cnumericalFlux.calculateExteriorNumericalDiffusiveFlux(self.mesh.exteriorElementBoundariesArray,
+                                                                               self.mesh.elementBoundaryElementsArray,
+                                                                               self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                               self.isDOFBoundary[ck],
+                                                                               ebqe['n'],
+                                                                               self.ebqe[('a',ci,ck)],
+                                                                               self.ebqe[('grad(phi)',ck)],
+                                                                               self.ebqe[('u',ck)],
+                                                                               ebqe[('a',ci,ck)],
+                                                                               ebqe[('grad(phi)',ck)],
+                                                                               ebqe[('u',ck)],
+                                                                               ebqe[('penalty')],
+                                                                               ebqe[('diffusiveFlux',ck,ci)],
+                                                                               self.scale_penalty,
+                                                                               self.penalty_floor)
+
+    def updateExteriorNumericalFluxJacobian(self,l2g,inflowFlag,q,ebqe,dphi,fluxJacobian_exterior,fluxJacobian_eb,fluxJacobian_hj):
+        for ci in range(self.nc):
+            if self.vt.timeIntegration.hamiltonianIsImplicit[ci]:
+                cnumericalFlux.updateExteriorNumericalAdvectiveFluxJacobian(self.mesh.exteriorElementBoundariesArray,
+                                                                            self.mesh.elementBoundaryElementsArray,
+                                                                            self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                            inflowFlag[ci],
+                                                                            ebqe[('dHamiltonJacobiFlux_left',ci,ci)],
+                                                                            ebqe[('v',ci)],
+                                                                            fluxJacobian_exterior[ci][ci])
+
+            if self.vt.timeIntegration.diffusionIsImplicit[ci]:
+                for ck in range(self.nc):
+                    if ebqe.has_key(('a',ci,ck)):
+                        for cj in range(self.nc):
+                            if dphi.has_key((ck,cj)):
+                                if self.vt.sd:
+                                    cnumericalFlux.updateExteriorNumericalDiffusiveFluxJacobian_sd(self.vt.coefficients.sdInfo[(ci,ck)][0],self.vt.coefficients.sdInfo[(ci,ck)][1],
+                                                                                                   dphi[(ck,cj)].femSpace.dofMap.l2g,
+                                                                                                   self.mesh.exteriorElementBoundariesArray,
+                                                                                                   self.mesh.elementBoundaryElementsArray,
+                                                                                                   self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                                                   self.isDOFBoundary[ck],
+                                                                                                   ebqe['n'],
+                                                                                                   ebqe[('a',ci,ck)],
+                                                                                                   ebqe[('da',ci,ck,cj)],
+                                                                                                   ebqe[('grad(phi)',ck)],
+                                                                                                   dphi[(ck,cj)].dof,
+                                                                                                   ebqe[('v',cj)],
+                                                                                                   ebqe[('grad(v)',cj)],
+                                                                                                   ebqe['penalty'],
+                                                                                                   fluxJacobian_exterior[ci][cj],
+                                                                                                   self.scale_penalty,
+                                                                                                   self.penalty_floor)
+                                else:
+                                    cnumericalFlux.updateExteriorNumericalDiffusiveFluxJacobian(dphi[(ck,cj)].femSpace.dofMap.l2g,
+                                                                                                self.mesh.exteriorElementBoundariesArray,
+                                                                                                self.mesh.elementBoundaryElementsArray,
+                                                                                                self.mesh.elementBoundaryLocalElementBoundariesArray,
+                                                                                                self.isDOFBoundary[ck],
+                                                                                                ebqe['n'],
+                                                                                                ebqe[('a',ci,ck)],
+                                                                                                ebqe[('da',ci,ck,cj)],
+                                                                                                ebqe[('grad(phi)',ck)],
+                                                                                                dphi[(ck,cj)].dof,
+                                                                                                ebqe[('v',cj)],
+                                                                                                ebqe[('grad(v)',cj)],
+                                                                                                ebqe['penalty'],
+                                                                                                fluxJacobian_exterior[ci][cj],
+                                                                                                self.scale_penalty,
+                                                                                                self.penalty_floor)
+
+
 
 class DarcyFCFF_IIPG_exterior(NF_base):
     hasInterior=False


### PR DESCRIPTION
…sion_SIPG_exterior for conservative pressure terms in the projection navier stokes methods in the velocity component

@cekees: @mfarthin :
I wish there were a way to include a switch to turn on and off this two line adjustment based on whether we want the advective flux or not.  Right now we have two of essentially the same Fluxes,  the standard one and the one that includes the two line advective adjustment of adding the term  'f' dot 'n'  to the existing HamiltonJacobiFlux, 

Is there a way to combine these into one functional Flux that can determine whether or not to add the term 'f'dot 'n' or not?

