### PR TITLE
put try/except around IPython display import

### DIFF
--- a/proteus/iproteus.py
+++ b/proteus/iproteus.py
@@ -21,7 +21,10 @@ from proteus import Profiling, Comm, version
 from warnings import *
 import optparse
 import sys
-from IPython.display import display,Markdown
+try:
+    from IPython.display import display,Markdown
+except:
+    pass
 import inspect
 
 def display_src(python_object):


### PR DESCRIPTION
optional dependencies of  IPython have changed so this can break
easily until we  decide what our standard IPython/Jupyter capabilities are  going to be.