### PR TITLE
some updates for POD DEIM and Hyper reduction cleanup

### DIFF
--- a/proteus/NonlinearSolvers.py
+++ b/proteus/NonlinearSolvers.py
@@ -1310,7 +1310,8 @@ class POD_HyperReduced_Newton2(Newton):
         self.hyper_indices_file = 'Hyper_indices'
         self.hyper_Q_file      = 'Hyper_Q'
         self.use_hyper = use_hyper
-	self.nonlinear = True
+        #mwf we could make this a little more descriptive so that it's clear what option is being set
+	self.residual_is_nonlinear = True
     def initialize_POD(self,u):
         """
         Setup for Full Nonlinear POD approximation
@@ -1434,7 +1435,7 @@ class POD_HyperReduced_Newton2(Newton):
                 #% (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
                 % (self.its-1,tol,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             self.pod_J.flat[:] = self.pod_lin_J.flat[:]
-            if self.nonlinear: #self.updateJacobian or self.fullNewton:
+            if self.residual_is_nonlinear: #self.updateJacobian or self.fullNewton:
                 #self.updateJacobian = False
                 self.F.getNonlinearJacobian(self.nonlin_J)
                 for i in range(self.DB):
@@ -1496,6 +1497,7 @@ class POD_HyperReduced_Newton2(Newton):
         self.norm_du_hist = []
         self.gammaK_max=0.0
         self.linearSolverFailed = False
+        #mwf we should return to a more general convergence test once the debugging is done
         tol = 1e+3
         while (tol >= 1e-4 and #not self.converged(pod_r) and
                not self.failed()):
@@ -1503,7 +1505,7 @@ class POD_HyperReduced_Newton2(Newton):
                 #% (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
                 % (self.its-1,tol,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             self.pod_J.flat[:] = self.pod_lin_J.flat[:]
-            if self.nonlinear: #self.updateJacobian or self.fullNewton:
+            if self.residual_is_nonlinear: #self.updateJacobian or self.fullNewton:
                 #self.updateJacobian = False
                 self.F.getNonlinearJacobian(self.nonlin_J)
                 self.pod_Jtmp[:] = 0.0
@@ -1550,9 +1552,10 @@ class POD_HyperReduced_Newton2(Newton):
         hyper_SVD_basis_file -- file holding Uf basis from SVD of snapshot nonlineariities ['Fn_SVD_basis']
         hyper_indices_file -- file with indices for hyper-reduction
         hyper_Q_file -- file with matrix Q for hyper-reduction approximation $\hat{F} = U^T \cdot Q P^T F(U z)$
+        residual_is_nonlinear -- Is the residual actually nonlinear so that we need to update the full Nonlinear portion 
         """
         optional_params = ['SVD_basis_file','use_hyper','hyper_SVD_basis_file',
-                           'hyper_indices_file','hyper_Q_file']
+                           'hyper_indices_file','hyper_Q_file','residual_is_nonlinear']
         for parm in optional_params:
             if parm in dir(nOptions):
                 setattr(self,parm,getattr(nOptions,parm))

--- a/proteus/Transport.py
+++ b/proteus/Transport.py
@@ -6752,7 +6752,7 @@ class OneLevelTransport(NonlinearEquation):
                 for dofN,g in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.iteritems():
                     r[self.offset[cj]+self.stride[cj]*dofN] = 0.0
             
-    def getLinearJacobian_CSR(self,jacobian,includeBoundaryAdjointInJacobian=False):
+    def getLinearJacobian_CSR(self,jacobian,includeBoundaryAdjointTermsInJacobian=False):
         """
         Add in the element jacobians to the linear portion of the global jacobian
         """
@@ -6892,7 +6892,7 @@ class OneLevelTransport(NonlinearEquation):
         #
         for ci,ckDict in self.coefficients.diffusion.iteritems():
             for ck in ckDict.keys():
-                if self.numericalFlux.includeBoundaryAdjoint and includeBoundaryAdjointInJacobian:
+                if self.numericalFlux.includeBoundaryAdjoint and includeBoundaryAdjointTermsInJacobian:
                     if self.sd:
                         if self.numericalFlux.hasInterior:
                             cfemIntegrals.updateGlobalJacobianFromInteriorElementBoundaryDiffusionAdjoint_CSR_sd(self.coefficients.sdInfo[(ci,ck)][0],self.coefficients.sdInfo[(ci,ck)][1],

--- a/proteus/Transport.py
+++ b/proteus/Transport.py
@@ -1599,6 +1599,10 @@ class OneLevelTransport(NonlinearEquation):
         for cj in range(self.nc):
             for dofN,g in self.dirichletConditions[cj].DOFBoundaryConditionsDict.iteritems():
                 self.u[cj].dof[dofN] = g(self.dirichletConditions[cj].DOFBoundaryPointDict[dofN],self.timeIntegration.t)
+        #what if we would like to perform a projection on the initial conditions?
+        if 'project_initial_conditions' in dir(self):
+            self.project_initial_conditions()
+            
     #what about setting initial conditions directly from dofs calculated elsewhere?
     def archiveAnalyticalSolutions(self,archive,analyticalSolutionsDict,T=0.0,tCount=0):
         import copy

--- a/proteus/deim_utils.py
+++ b/proteus/deim_utils.py
@@ -235,3 +235,25 @@ def extract_sub_matrix_csr(rho,rowptr,colind,nnzval):
             nzval_sub[rowptr_sub[k]+m]=nnzval[MM]
     #
     return rowptr_sub,colind_sub,nzval_sub
+
+#going to try to monkey patch Transport Model when setting initial conditions 
+def project_initial_conditions(self):
+    """
+    Set the Transport model to use the projection of the initial 
+    condition in some base bases rather than the initial 
+    condition in the fine space
+ 
+    Work In Progress
+    """
+
+    assert 'setFreeDOF' in dir(self)
+    assert  'setUnknowns' in dir(self)
+    assert 'ic_projection_matrix' in dir(self) #original space to reduced/target space
+    assert 'ic_global_vector' in dir(self) #size of complete degree of freedom
+
+    self.setFreeDOF(self.ic_global_vector) #copy models degrees of freedom to global vector
+    projected_ics = numpy.dot(self.ic_projection_matrix,self.ic_global_vector) #project to reduced/target space dofs
+    self.ic_global_vector[:] = numpy.dot(self.ic_projection_matrix.T,projected_ics) #back to fine space
+    self.setUnknowns(self.du) #set models degrees of freedom from global vector
+
+    

--- a/proteus/tests/POD/test_deim.py
+++ b/proteus/tests/POD/test_deim.py
@@ -77,6 +77,48 @@ def test_nonlin_residual_split():
     res_n += res_l
     npt.assert_almost_equal(res,res_n)
 
+def test_nonlin_jacobian_split():
+    """
+    just tests that J=J_l+J_n for random dof vector in [0,1]
+
+    Here J_l and J_n are the linear and nonlinear portions of the Jacobian
+    """
+    ns = get_burgers_ns("test_jac_split",T=0.05,nDTout=5)
+    failed = ns.calculateSolution("run_jac_test")
+    assert not failed
+    #storage for residuals
+    model = ns.modelList[0].levelModelList[-1]
+    u_tmp = np.random.random(model.u[0].dof.shape)
+    res = np.zeros(model.u[0].dof.shape,'d')
+    res_n = res.copy(); res_l=res.copy()
+    model.getResidual(u_tmp,res)
+    model.getNonlinearResidual(u_tmp,res_n)
+    model.getLinearResidual(u_tmp,res_l)
+    
+    res_n += res_l
+    npt.assert_almost_equal(res,res_n)
+    #sparse storage for nonlinear and linear jacobians
+    nonlin_J = model.initializeNonlinearJacobian()
+    nonlin_J_rowptr,nonlin_J_colind,nonlin_J_nzval = nonlin_J.getCSRrepresentation()
+
+    npt.assert_almost_equal(nonlin_J_rowptr,model.rowptr)
+    npt.assert_almost_equal(nonlin_J_colind,model.colind)
+    
+    lin_J = model.initializeLinearJacobian()
+    lin_J_rowptr,lin_J_colind,lin_J_nzval = lin_J.getCSRrepresentation()
+
+    npt.assert_almost_equal(lin_J_rowptr,model.rowptr)
+    npt.assert_almost_equal(lin_J_colind,model.colind)
+
+    
+    model.getLinearJacobian(lin_J)
+    model.getNonlinearJacobian(nonlin_J)
+    model.getJacobian(model.jacobian)
+
+    nonlin_J_nzval += lin_J_nzval
+    npt.assert_almost_equal(nonlin_J_nzval,model.nzval)
+    
+    
 def test_res_archive():
     """
     smoke test if numerical solution can archive hyper reduction residuals' to xdmf  
@@ -183,7 +225,7 @@ def test_svd_soln():
     """
     from proteus.deim_utils import read_snapshots,generate_svd_decomposition
 
-    ns = get_burgers_ns("test_svd_soln",T=0.1,nDTout=10,archive_pod_res='pod_residuals_timespace')
+    ns = get_burgers_ns("test_svd_soln",T=0.1,nDTout=10,archive_pod_res='pod_residuals_nonlin')
     
     failed = ns.calculateSolution("run_svd_soln")
     assert not failed
@@ -218,10 +260,10 @@ def test_deim_indices():
     rho_uni = np.unique(rho)
     assert rho_uni.shape[0] == rho.shape[0]
 
-def deim_approx(T=0.1,nDTout=10,m=5,m_mass=5):
+def deim_approx(T=0.1,nDTout=10,m=5,m_linear=5):
     """
     Follow basic setup for DEIM approximation
-    - generate a burgers solution, saving spatial and 'mass' residuals
+    - generate a burgers solution, saving nonlinear and linear residuals
     - generate SVDs for snapshots
     - for both residuals F_s and F_m
       - pick $m$, dimension for snapshot reduced basis $\mathbf{U}_m$
@@ -239,7 +281,7 @@ def deim_approx(T=0.1,nDTout=10,m=5,m_mass=5):
 
     from proteus.deim_utils import read_snapshots,generate_svd_decomposition
     ##run fine grid problem
-    ns = get_burgers_ns("test_deim_approx",T=T,nDTout=nDTout,archive_pod_res='pod_residuals_timespace')
+    ns = get_burgers_ns("test_deim_approx",T=T,nDTout=nDTout,archive_pod_res='pod_residuals_linnonlin')
     
     failed = ns.calculateSolution("run_deim_approx")
     assert not failed
@@ -247,52 +289,52 @@ def deim_approx(T=0.1,nDTout=10,m=5,m_mass=5):
     from proteus import Archiver
     archive = Archiver.XdmfArchive(".","test_deim_approx",readOnly=True)
     ##perform SVD on spatial residual
-    U,s,V=generate_svd_decomposition(archive,len(ns.tnList),'spatial_residual0','F_s')
-    U_m,s_m,V_m=generate_svd_decomposition(archive,len(ns.tnList),'mass_residual0','F_m')
+    U,s,V=generate_svd_decomposition(archive,len(ns.tnList),'nonlinear_residual0','F_s')
+    U_l,s_l,V_l=generate_svd_decomposition(archive,len(ns.tnList),'linear_residual0','F_m')
 
     from proteus.deim_utils import deim_alg
     ##calculate DEIM indices and projection matrix
     rho,PF = deim_alg(U,m)
-    #also 'mass' term
-    rho_m,PF_m = deim_alg(U_m,m_mass)
+    #also 'linear' term
+    rho_l,PF_l = deim_alg(U_l,m_linear)
 
     ##for comparison, grab snapshots of solution and residual
     Su = read_snapshots(archive,len(ns.tnList),'u')
-    Sf = read_snapshots(archive,len(ns.tnList),'spatial_residual0')
-    Sm = read_snapshots(archive,len(ns.tnList),'mass_residual0')
+    Sn = read_snapshots(archive,len(ns.tnList),'nonlinear_residual0')
+    Sl = read_snapshots(archive,len(ns.tnList),'linear_residual0')
 
     steps_to_test = np.arange(len(ns.tnList)) 
-    errors = np.zeros(len(steps_to_test),'d'); errors_mass = errors.copy()
+    errors = np.zeros(len(steps_to_test),'d'); errors_lin = errors.copy()
 
-    F_deim = np.zeros((Sf.shape[0],len(steps_to_test)),'d')
-    Fm_deim = np.zeros((Sf.shape[0],len(steps_to_test)),'d')
+    F_deim = np.zeros((Sn.shape[0],len(steps_to_test)),'d')
+    Fl_deim = np.zeros((Sl.shape[0],len(steps_to_test)),'d')
     for i,istep in enumerate(steps_to_test):
         #solution on the fine grid
         u = Su[:,istep]
-        #spatial residual evaluated from fine grid
-        F = Sf[:,istep]
+        #nonlinear residual evaluated from fine grid
+        F = Sn[:,istep]
         #deim approximation on the fine grid 
         F_deim[:,istep] = np.dot(PF,F[rho])
         errors[i] = np.linalg.norm(F-F_deim[:,istep])
         #repeat for 'mass residual'
-        Fm= Sm[:,istep]
+        Fl= Sl[:,istep]
         #deim approximation on the fine grid 
-        Fm_deim[:,istep] = np.dot(PF_m,Fm[rho])
-        errors_mass[i] = np.linalg.norm(Fm-Fm_deim[:,istep])
+        Fl_deim[:,istep] = np.dot(PF_l,Fl[rho_l])
+        errors_lin[i] = np.linalg.norm(Fl-Fl_deim[:,istep])
     #
-    np.savetxt("deim_approx_errors_space_test_T={0}_nDT={1}_m={2}.dat".format(T,nDTout,m),errors)
-    np.savetxt("deim_approx_errors_mass_test_T={0}_nDT={1}_m={2}.dat".format(T,nDTout,m_mass),errors_mass)
+    np.savetxt("deim_approx_errors_nonlinear_test_T={0}_nDT={1}_m={2}.dat".format(T,nDTout,m),errors)
+    np.savetxt("deim_approx_errors_linear_test_T={0}_nDT={1}_m={2}.dat".format(T,nDTout,m_linear),errors_lin)
         
-    return errors,errors_mass,F_deim,Fm_deim
+    return errors,errors_lin,F_deim,Fl_deim
 
 def test_deim_approx_full(tol=1.0e-12):
     """
     check that get very small error if use full basis 
     """
     T = 0.1; nDTout=10; m=nDTout+1
-    errors,errors_mass,F_deim,Fm_deim = deim_approx(T=T,nDTout=nDTout,m=m,m_mass=m)
+    errors,errors_linear,F_deim,Fl_deim = deim_approx(T=T,nDTout=nDTout,m=m,m_linear=m)
     assert errors.min() < tol
-    assert errors_mass.min() < tol
+    assert errors_linear.min() < tol
 
 if __name__ == "__main__":
     from proteus import Comm


### PR DESCRIPTION
This is not ready to merge yet.

@MajinSaha I believe `cleanup_deim` is about ready for a pull request into master. This has some modifications that I'd like us to finish before doing a pull request though.

- [x] Implement 'general' nonlinear and linear splitting for residuals and jacobians
- [ ] get rid of spatial and temporal splitting between residuals and jacobins
- [ ] Combine `POD_Newton` and `POD_HyperNewton` into one class that can do full nonlinear POD or hyper reduction based on user input
- [x] Add tests for new functionality in `test_deim.py` and make sure all of the tests pass
- [ ] Put back general user-specified tolerance in POD Newton solvers 
- [ ] Switch initial condition to use projection from POD instead of fine grid solution