### PR TITLE
Raises and possibly addresses a bug in the multilevelprojection class.

### DIFF
--- a/proteus/FemTools.py
+++ b/proteus/FemTools.py
@@ -6606,7 +6606,7 @@ class MultilevelProjectionOperators:
                 #end coarse_eN
                 for I in range(coarseSpace.dim):
                     for J in rbcColumnIndeces[I]:
-                        rbcSum[I] += rbc[(I,J)]
+                        rbcSum[I] += abs(rbc[(I,J)])
                         if rbc[(I,J)] > 1.0-1.0e-8 and rbc[(I,J)] < 1.0 + 1.0e-8:
                             interp_bc[(I,J)] = 1.0
                 for I in range(offsetListList[l][cj],offsetListList[l][cj]+coarseDOFBoundaryConditions.nFreeDOF_global,strideListList[l][cj]):
@@ -6614,7 +6614,10 @@ class MultilevelProjectionOperators:
                         rSum[I] += r[(I,J)]
                 for I in range(coarseSpace.dim):
                     for J in rbcColumnIndeces[I]:
-                        scaled_rbc[(I,J)] = rbc[(I,J)]/rbcSum[I]
+                        if rbc[(I,J)] > 0.0 - 1.0e-8 and rbc[(I,J)] < 0.0 + 1.0e-8:
+                            scaled_rbc[(I,J)] = 0.0
+                        else:
+                            scaled_rbc[(I,J)] = rbc[(I,J)]/rbcSum[I]
                 #now make real sparse matrices
                 (rbc,rbczval) = SparseMatFromDict(coarseSpace.dim,fineSpace.dim,rbc)
                 (scaled_rbc,scaled_rbczval) = SparseMatFromDict(coarseSpace.dim,fineSpace.dim,scaled_rbc)


### PR DESCRIPTION
	- Since the interpolation functionals can return positive or
	 negative values it is possible rbcSum can be zero after
	 completion of the loop even if the interpolationfunctional
	 return non-zero numbers.
	- This can cause issues in line 6617 when rbcSum is used
	 to scale the rbc values.
	- I believe the best solution is to make rbcSum the sum
	 of positive numbers and avoiding the scaling in the corner
	 case where all interpolation values are zero.
	- As I'm not familiar with the multilevelprojection algorithm,
	 this solution may not be appropriate.