### PR TITLE
Added exception to bdm/rt post-processing.

### DIFF
--- a/proteus/MeshTools.py
+++ b/proteus/MeshTools.py
@@ -2120,6 +2120,8 @@ class TetrahedralMesh(Mesh):
         self.tetrahedronList=[]
         self.oldToNewNode=[]
         self.boundaryMesh=TriangularMesh()
+    def meshType(self):
+        return 'simplex'
     def computeGeometricInfo(self):
         import cmeshTools
         cmeshTools.computeGeometricInfo_tetrahedron(self.cmesh)
@@ -2709,7 +2711,8 @@ class HexahedralMesh(Mesh):
         self.elemList=[]
         self.oldToNewNode=[]
         self.boundaryMesh=QuadrilateralMesh()
-
+    def meshType(self):
+        return 'cuboid'
     def computeGeometricInfo(self):
         import cmeshTools
         print "no info yet for hexahedral mesh"
@@ -3747,6 +3750,8 @@ class TriangularMesh(Mesh):
         self.triangleDict={}
         self.triangleList=[]
         self.oldToNewNode=[]
+    def meshType(self):
+        return 'simplex'
     def computeGeometricInfo(self):
         import cmeshTools
         cmeshTools.computeGeometricInfo_triangle(self.cmesh)
@@ -4423,6 +4428,9 @@ class QuadrilateralMesh(Mesh):
                 e3 = Edge(nodes=[n3,n0])
                 self.newQuadrilateral([e0,e1,e2,e3])
         self.finalize()
+    
+    def meshType(self):
+        return 'cuboid'
 
     def meshInfo(self):
         minfo = """Number of quadrilaterals  : %d

--- a/proteus/PostProcessingTools.py
+++ b/proteus/PostProcessingTools.py
@@ -484,6 +484,12 @@ class VPP_PWL_RT0(VelocityPostProcessingAlgorithmBase):
         #how is the local velocity represented
         #  2 -- RT0, local rep is \sum^d_{i=0}V^i\vec N_{T,i},
         #           \vec N_{T,i} = \frac{1}{d|E|}(\vec x - p_i), i=0,...,d
+        if self.vt.mesh.meshType() != 'simplex':
+            raise Exception, 'Proteus currently only supports conservative '\
+                'flux post-processing on triangular and tetrahedral meshes.  ' \
+                'Try removing the post-processing flag or changing your ' \
+                'mesh/finite element type.'
+
         self.localVelocityRepresentationFlag = 2
 
         self.omitFluxBoundaryNodes=omitFluxBoundaryNodes


### PR DESCRIPTION
      - Currently the BDM/RT post-processing scheme only supports
      triangular and tetrahedral meshes.  This exception raises
      if users try to post-process with quad or hexaderal meshes.