### PR TITLE
adds configuration changes for compiling on OS X 10.11.4 with clang 7.3.0

### DIFF
--- a/proteus/config/default.py
+++ b/proteus/config/default.py
@@ -22,6 +22,7 @@ if sys.platform == 'darwin':
     platform_lapack_integer = '__CLPK_integer'
     platform_blas_h = r'<Accelerate/Accelerate.h>'
     platform_lapack_h = r'<Accelerate/Accelerate.h>'
+    platform_extra_compile_args = ['-flax-vector-conversions','-DPETSC_SKIP_COMPLEX']
 elif sys.platform == 'linux2':
     platform_extra_compile_args = ['-DPETSC_INCLUDE_AS_C']
     platform_extra_link_args = ['-Wl,-rpath,' + PROTEUS_LIB_DIR]


### PR DESCRIPTION
- requires hashdist/hashstack pull request #946
- Defines `PETSC_SKIP_COMPLEX` to avoid template conflicts from `<complex>` inclusion in `petscmath.h`

- adds a compiler flag to allow looser pointer conversions
