### PR TITLE
added prototype of gmsh support

### DIFF
--- a/proteus/Domain.py
+++ b/proteus/Domain.py
@@ -301,6 +301,27 @@ shipout();
     def writeXdmf(self,ar):
         raise UserWarning("Xdmf output not implemented")
 
+class GMSH_3D_Domain(D_base):
+    """
+    A domain described by a gmsh .geo file
+
+    Parameters
+    ----------
+    geofile : str
+              The base filename of the main .geo file
+    he : float
+         The maximum element diameter (this should go way)
+    name : str
+           A name for the domain
+    units : str
+            The units of length
+    """
+    def __init__(self, geofile, he, name="GMSH_Domain", units="m"):
+        D_base.__init__(self, 2, name, units)
+        self.geofile=geofile+".geo"
+        self.polyfile=geofile
+        self.he = he
+
 class PlanarStraightLineGraphDomain(D_base):
     """
     2D domains described by planar straight line graphs.

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -344,6 +344,65 @@ class NS_base:  # (HasTraits):
                 mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                       nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                       parallelPartitioningType=n.parallelPartitioningType)
+            elif isinstance(p.domain,Domain.GMSH_3D_Domain):
+                from subprocess import call
+                import sys
+                if comm.rank() == 0 and (p.genMesh or not (os.path.exists(p.domain.polyfile+".ele") and
+                                                           os.path.exists(p.domain.polyfile+".node") and
+                                                           os.path.exists(p.domain.polyfile+".face"))):
+                    log("Running gmsh to generate 3D mesh for "+p.name,level=1)
+                    gmsh_cmd = "time gmsh {0:s} -v 10 -3 -o {1:s}  -format mesh  -clmax {2:f} -clscale {2:f}".format(p.domain.geofile, p.domain.name+".mesh", p.domain.he)
+
+                    log("Calling gmsh on rank 0 with command %s" % (gmsh_cmd,))
+
+                    check_call(gmsh_cmd, shell=True)
+
+                    log("Done running gmsh; converting to tetgen")
+
+                    gmsh2tetgen_cmd = "gmsh2tetgen {0}".format(p.domain.name+".mesh")
+
+                    check_call(gmsh2tetgen_cmd, shell=True)
+
+                    elefile  = "mesh.ele"
+                    nodefile = "mesh.node"
+                    facefile = "mesh.face"
+                    edgefile = "mesh.edge"
+                    assert os.path.exists(elefile), "no mesh.ele"
+                    tmp = "%s.ele" % p.domain.polyfile
+                    os.rename(elefile,tmp)
+                    assert os.path.exists(tmp), "no .ele"
+                    assert os.path.exists(nodefile), "no mesh.node"
+                    tmp = "%s.node" % p.domain.polyfile
+                    os.rename(nodefile,tmp)
+                    assert os.path.exists(tmp), "no .node"
+                    if os.path.exists(facefile):
+                        tmp = "%s.face" % p.domain.polyfile
+                        os.rename(facefile,tmp)
+                        assert os.path.exists(tmp), "no .face"
+                    if os.path.exists(edgefile):
+                        tmp = "%s.edge" % p.domain.polyfile
+                        os.rename(edgefile,tmp)
+                        assert os.path.exists(tmp), "no .edge"
+                comm.barrier()
+                log("Initializing mesh and MultilevelMesh")
+                nbase = 1
+                mesh=MeshTools.TetrahedralMesh()
+                mlMesh = MeshTools.MultilevelTetrahedralMesh(0,0,0,skipInit=True,
+                                                             nLayersOfOverlap=n.nLayersOfOverlapForParallel,
+                                                             parallelPartitioningType=n.parallelPartitioningType)
+                if opts.generatePartitionedMeshFromFiles:
+                    log("Generating partitioned mesh from Tetgen files")
+                    mlMesh.generatePartitionedMeshFromTetgenFiles(p.domain.polyfile,nbase,mesh,n.nLevels,
+                                                                  nLayersOfOverlap=n.nLayersOfOverlapForParallel,
+                                                                  parallelPartitioningType=n.parallelPartitioningType)
+                else:
+                    log("Generating coarse global mesh from Tetgen files")
+                    mesh.generateFromTetgenFiles(p.domain.polyfile,nbase,parallel = comm.size() > 1)
+                    log("Generating partitioned %i-level mesh from coarse global Tetgen mesh" % (n.nLevels,))
+                    mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
+                                                          nLayersOfOverlap=n.nLayersOfOverlapForParallel,
+                                                          parallelPartitioningType=n.parallelPartitioningType)
+
             mlMesh_nList.append(mlMesh)
             if opts.viewMesh:
                 log("Attempting to visualize mesh")


### PR DESCRIPTION
This adds the ability to do

```
domain = GMSH_3D_Domain("assembly", he=10.0)
```
where `assembly.geo` is  the main gmsh file describing a  domain and `he` is the max  element diameter. The only example I have now is in 3d/dtmb on this commit, but it appears to be working:

https://github.com/erdc-cm/air-water-vv/commit/70954d5d4f5cbcc747e5469c0dcc76e3f484407d

I would prefer that the `he` get set through @tridelat 's new MeshOptions class, but other than that I'm not sure how fancy to make it. I think we should probably push most of the work  of setting up the geometry and specifying the mesh generation onto  gmsh itself (and the writer of the actual .geo file) so the focus for  people  using the gmsh pre-processing will be on learning gmsh, not a proteus interface  to it.

/cc  @tridelat  @alistairbntl @adimako 