### PR TITLE
Replaces log instances with logEvent.

### DIFF
--- a/proteus/Archiver.py
+++ b/proteus/Archiver.py
@@ -5,12 +5,12 @@ Classes for archiving numerical solution data
    :parts: 1
 """
 import Profiling
+from Profiling import logEvent
 import Comm
 import numpy
 import os
 from xml.etree.ElementTree import *
 
-log = Profiling.logEvent
 memory = Profiling.memory
 
 def indentXML(elem, level=0):
@@ -241,7 +241,7 @@ class AR_base:
             self.xmlFileGlobal.seek(0)
             self.xmlFileGlobal.truncate()
     def close(self):
-        log("Closing Archive")
+        logEvent("Closing Archive")
         if not self.useGlobalXMF:
             self.xmlFile.close()
         if self.comm.isMaster() and self.useGlobalXMF:
@@ -249,7 +249,7 @@ class AR_base:
             self.xmlFileGlobal.close()
         if self.hdfFile != None:
             self.hdfFile.close()
-        log("Done Closing Archive")
+        logEvent("Done Closing Archive")
         try:
             if not self.useGlobalXMF:
                 if self.gatherAtClose:
@@ -257,7 +257,7 @@ class AR_base:
         except:
             pass
     def allGather(self):
-        log("Gathering Archive")
+        logEvent("Gathering Archive")
         self.comm.barrier()
         if self.rank==0:
             #replace the bottom level grid with a spatial collection
@@ -287,11 +287,11 @@ class AR_base:
             indentXML(self.tree.getroot())
             self.tree.write(f)
             f.close()
-        log("Done Gathering Archive")
+        logEvent("Done Gathering Archive")
     def allGatherIncremental(self):
         import copy
         from mpi4py import MPI
-        log("Gathering Archive Time step")
+        logEvent("Gathering Archive Time step")
         self.comm.barrier()
         XDMF =self.tree.getroot()
         Domain =XDMF[-1]
@@ -362,9 +362,9 @@ class AR_base:
                     if self.comm.isMaster():
                         xml_data[0] = tostring(GridLocal)
         self.n_datasets += 1
-        log("Done Gathering Archive Time Step")
+        logEvent("Done Gathering Archive Time Step")
     def sync(self):
-        log("Syncing Archive",level=3)
+        logEvent("Syncing Archive",level=3)
         memory()
         self.allGatherIncremental()
         self.clear_xml()
@@ -397,8 +397,8 @@ class AR_base:
                 self.comm.barrier()
             else:
                 self.hdfFile.flush()
-        log("Done Syncing Archive",level=3)
-        log(memory("Syncing Archive"),level=4)
+        logEvent("Done Syncing Archive",level=3)
+        logEvent(memory("Syncing Archive"),level=4)
     def create_dataset_async(self,name,data):
         comm_world = self.comm.comm.tompi4py()
         metadata = comm_world.allgather((name,data.shape,data.dtype))

--- a/proteus/AuxiliaryVariables.py
+++ b/proteus/AuxiliaryVariables.py
@@ -5,10 +5,11 @@ Classes for calculating auxiliary variables based on the numerical solution.
    :parts: 1
 """
 import numpy
-import Profiling
 import Viewers
 import Archiver
 from xml.etree.ElementTree import *
+
+from Profiling import logEvent
 
 try:
     from proteusGraphical import vtkViewers
@@ -19,7 +20,6 @@ import cfemIntegrals
 import math
 import os
 
-log = Profiling.logEvent
 class AV_base:
     def __init__(self):
         pass
@@ -105,7 +105,7 @@ class BoundaryForce(AV_base):
             elif self.nd == 3:
                 F = numpy.zeros((self.nForces,3),'d')
             else:
-                log("Can't use stress computation for nd = "+`self.nd`)
+                logEvent("Can't use stress computation for nd = "+`self.nd`)
                 F=None
             self.levelFlist.append(F)
         self.historyF=[]
@@ -142,17 +142,17 @@ class BoundaryForce(AV_base):
                                                                        m.ebqe[('dS_u',0)],#dS
                                                                        m.ebqe[('n')],
                                                                        F)
-            log("Force")
-            log(`F`)
+            logEvent("Force")
+            logEvent(`F`)
             Ftot=F[0,:]
             for ib in range(1,self.nForces):
                 Ftot+=F[ib,:]
-            log("Total force on all boundaries")
-            log(`Ftot`)
-        log("Drag Force " +`self.model.stepController.t_model`+" "+`F[-1,0]`)
-        log("Lift Force " +`self.model.stepController.t_model`+" "+`F[-1,1]`)
-        log("Drag Coefficient " +`self.model.stepController.t_model`+" "+`self.C_fact*F[-1,0]`)
-        log("Lift Coefficient " +`self.model.stepController.t_model`+" "+`self.C_fact*F[-1,1]`)
+            logEvent("Total force on all boundaries")
+            logEvent(`Ftot`)
+        logEvent("Drag Force " +`self.model.stepController.t_model`+" "+`F[-1,0]`)
+        logEvent("Lift Force " +`self.model.stepController.t_model`+" "+`F[-1,1]`)
+        logEvent("Drag Coefficient " +`self.model.stepController.t_model`+" "+`self.C_fact*F[-1,0]`)
+        logEvent("Lift Coefficient " +`self.model.stepController.t_model`+" "+`self.C_fact*F[-1,1]`)
 #        for ib in range(self.nForces):
 #             self.writeScalarXdmf(self.C_fact*F[ib,0],"Drag Coefficient %i" % (ib,))
 #             self.writeScalarXdmf(self.C_fact*F[ib,1],"Lift Coefficient %i" % (ib,))
@@ -206,7 +206,7 @@ class PressureProfile(AV_base):
             elif self.nd == 3:
                 pass
             else:
-                log("Can't use stress computation for nd = "+`self.nd`)
+                logEvent("Can't use stress computation for nd = "+`self.nd`)
                 pass
             self.levelPlist.append(p)
             self.levelThetalist.append(theta)
@@ -344,7 +344,7 @@ class RecirculationLength(AV_base):
 #             self.viewL()
 #         except:
 #             pass
-        log("Recirculation Length "+`self.levelLlist[-1]`)
+        logEvent("Recirculation Length "+`self.levelLlist[-1]`)
 #     def viewL(self):
 #         tList=[]
 #         LList=[]
@@ -389,7 +389,7 @@ class VelocityAverage(AV_base):
             elif self.nd == 3:
                 V = numpy.zeros((3,),'d')
             else:
-                log("Can't use velocity average for nd = "+`self.nd`)
+                logEvent("Can't use velocity average for nd = "+`self.nd`)
                 V=None
             self.levelVlist.append(V)
 #         self.historyV=[]
@@ -423,8 +423,8 @@ class VelocityAverage(AV_base):
 #                                                                m.q[('u',2)],#v
 #                                                                m.q[('dV_u',0)],#dV
 #                                                                V)
-            log("Average Velocity")
-            log(`V`)
+            logEvent("Average Velocity")
+            logEvent(`V`)
             if self.nd == 2:
                 self.Vfile.write('%21.15e %21.15e \n' % tuple(V))
             else:
@@ -478,8 +478,8 @@ class BoundaryPressure(AV_base):
             for i in range(len(A)):#could do this in a fancier way with numpy
                 if abs(A[i]) > 0.0:
                     P[i] /= A[i]
-            log("Pressure")
-            log(`P`)
+            logEvent("Pressure")
+            logEvent(`P`)
         self.historyP.append(copy.deepcopy(self.levelPlist))
 
 class ConservationHistoryMC(AV_base):
@@ -572,7 +572,7 @@ class VelocityNormOverRegion(AV_base):
                         results['L2'] += e2*m.q[('dV_u',0)][eN,k]
                         results['L1'] += e1*m.q[('dV_u',0)][eN,k]
                         results['LI'] = max(results['LI'],ei)
-            log("Velocity Norms in Region %s L2= %s L1= %s LI= %s " % (self.regionIdList,results['L2'],results['L1'],results['LI']))
+            logEvent("Velocity Norms in Region %s L2= %s L1= %s LI= %s " % (self.regionIdList,results['L2'],results['L1'],results['LI']))
             self.Vfile.write('%21.15e %21.15e %21.15e\n' % (results['L2'],results['L1'],results['LI']))
 
 class MassOverRegion(AV_base):
@@ -625,9 +625,9 @@ class MassOverRegion(AV_base):
                         results['L1'] += e1*m.q[('dV_u',ci)][eN,k]
                         results['LI'] = max(results['LI'],ei)
             if self.regionIdList==None:
-                log("Mass Norms in Domain Total= %s L2= %s L1= %s LI= %s " % (results['total'],results['L2'],results['L1'],results['LI']))
+                logEvent("Mass Norms in Domain Total= %s L2= %s L1= %s LI= %s " % (results['total'],results['L2'],results['L1'],results['LI']))
             else:
-                log("Mass Norms in Domain %s Total= %s L2= %s L1= %s LI= %s " % (self.regionIdList,results['total'],results['L2'],results['L1'],results['LI']))
+                logEvent("Mass Norms in Domain %s Total= %s L2= %s L1= %s LI= %s " % (self.regionIdList,results['total'],results['L2'],results['L1'],results['LI']))
             self.ofile.write('%21.15e %21.15e %21.15e %21.15e\n' % (results['total'],results['L2'],results['L1'],results['LI']))
 
 class PT123velocityGenerator(AV_base):

--- a/proteus/Comm.py
+++ b/proteus/Comm.py
@@ -9,7 +9,7 @@ import ctypes
 import sys
 
 import petsc4py
-from .Profiling import logEvent as log
+from .Profiling import logEvent
 
 
 # Special workaround for broken MPI on certain Cray systems
@@ -44,7 +44,7 @@ def init():
 
 def get():
     if comm is None:
-        log("Comm.get called before init, init is being called for you.", 3)
+        logEvent("Comm.get called before init, init is being called for you.", 3)
         return init()
     return comm
 

--- a/proteus/FemTools.py
+++ b/proteus/FemTools.py
@@ -6141,7 +6141,7 @@ class FiniteElementFunction:
         build data structure for parallel communication
         """
         if self.femSpace.dofMap.dof_offsets_subdomain_owned == None:
-            log("WARNING setupParallelCommunication not valid for %s must have parallel information for dofMap" % self,level=-1)
+            logEvent("WARNING setupParallelCommunication not valid for %s must have parallel information for dofMap" % self,level=-1)
             return
         comm = Comm.get()
         par_n = self.femSpace.dofMap.dof_offsets_subdomain_owned[comm.rank()+1] - self.femSpace.dofMap.dof_offsets_subdomain_owned[comm.rank()]

--- a/proteus/Gauges.py
+++ b/proteus/Gauges.py
@@ -15,7 +15,7 @@ from numpy.linalg import norm
 
 from . import Comm
 from .AuxiliaryVariables import AV_base
-from .Profiling import logEvent as log
+from .Profiling import logEvent
 from proteus.MeshTools import triangleVerticesToNormals, tetrahedronVerticesToNormals, getMeshIntersections
 from proteus import Profiling
 
@@ -213,12 +213,12 @@ class Gauges(AV_base):
         haveElement = int(local_element is not None)
         global_have_element, owning_proc = comm.allreduce(haveElement, op=MPI.MAXLOC)
         if global_have_element:
-            log("Gauges on element at location: [%g %g %g] assigned to %d" % (location[0], location[1], location[2],
+            logEvent("Gauges on element at location: [%g %g %g] assigned to %d" % (location[0], location[1], location[2],
                                                                     owning_proc), 3)
         else:
             # gauge isn't on any of the elements, just use nearest node
             global_min_distance, owning_proc = comm.allreduce(nearest_node_distance, op=MPI.MINLOC)
-            log("Off-element gauge location: [%g %g %g] assigned to %d" % (location[0], location[1], location[2],
+            logEvent("Off-element gauge location: [%g %g %g] assigned to %d" % (location[0], location[1], location[2],
                                                                  owning_proc), 3)
         if comm_rank != owning_proc:
             nearest_node = None
@@ -280,10 +280,10 @@ class Gauges(AV_base):
                     quantityIDs[gaugeProc] += 1
                     assert gaugeProc >= 0
                     self.globalMeasuredQuantities[field][id] = location, gaugeProc, quantityID
-                    log("Gauge for %s[%d] at %e %e %e is at P[%d][%d]" % (field, id, location[0], location[1],
+                    logEvent("Gauge for %s[%d] at %e %e %e is at P[%d][%d]" % (field, id, location[0], location[1],
                                                                           location[2], gaugeProc, quantityID), 5)
 
-            log("Quantity IDs:\n%s" % str(quantityIDs), 5)
+            logEvent("Quantity IDs:\n%s" % str(quantityIDs), 5)
 
             # determine mapping from global measured quantities to communication buffers
             self.globalQuantitiesMap = np.zeros(numGlobalQuantities, dtype=np.int)
@@ -301,7 +301,7 @@ class Gauges(AV_base):
             # final ids also equal to the counts on each process
             self.globalQuantitiesCounts = quantityIDs
             self.globalQuantitiesBuf = np.zeros(numGlobalQuantities, dtype=np.double)
-            log("Global Quantities Map: \n%s" % str(self.globalQuantitiesMap), 5)
+            logEvent("Global Quantities Map: \n%s" % str(self.globalQuantitiesMap), 5)
 
         self.outputWriterReady = True
 
@@ -323,7 +323,7 @@ class Gauges(AV_base):
         self.isGaugeOwner = comm.rank in gaugeOwners
         gaugeComm = comm.Split(color=self.isGaugeOwner)
 
-        log("Gauge owner: %d" % self.isGaugeOwner, 5)
+        logEvent("Gauge owner: %d" % self.isGaugeOwner, 5)
         if self.isGaugeOwner:
             self.gaugeComm = gaugeComm
             gaugeRank = self.gaugeComm.rank
@@ -331,7 +331,7 @@ class Gauges(AV_base):
             self.gaugeComm = None
             gaugeRank = -1
         self.globalGaugeRanks = comm.allgather(gaugeRank)
-        log("Gauge ranks: \n%s" % str(self.globalGaugeRanks), 5)
+        logEvent("Gauge ranks: \n%s" % str(self.globalGaugeRanks), 5)
 
 
     def addLineGaugePoints(self, line, line_segments):
@@ -362,7 +362,7 @@ class Gauges(AV_base):
             new_points[point] = points[point]
 
         for segment in line_segments:
-            log("Processing segment [ %e %e %e ] to [ %e %e %e ]" % (
+            logEvent("Processing segment [ %e %e %e ] to [ %e %e %e ]" % (
                 segment[0][0], segment[0][1], segment[0][2],
                 segment[1][0], segment[1][1], segment[1][2]), 5)
             startPoint, endPoint = segment
@@ -412,7 +412,7 @@ class Gauges(AV_base):
                 self.globalMeasuredQuantities[field].append((point, owningProc))
                 if nearestNode is not None:
                     point_id = len(self.measuredQuantities[field])
-                    log("Gauge for %s[%d] at %e %e %e is closest to node %d" % (field, point_id, point[0], point[1],
+                    logEvent("Gauge for %s[%d] at %e %e %e is closest to node %d" % (field, point_id, point[0], point[1],
                                                                                 point[2], nearestNode), 3)
                     l_d[field] = point_id
                     self.measuredQuantities[field].append((point, nearestNode))
@@ -440,7 +440,7 @@ class Gauges(AV_base):
             femFun = self.u[field_id]
             for quantity_id, quantity in enumerate(self.measuredQuantities[field]):
                 location, node = quantity
-                log("Gauge for: %s at %e %e %e is on local operator row %d" % (field, location[0], location[1],
+                logEvent("Gauge for: %s at %e %e %e is on local operator row %d" % (field, location[0], location[1],
                                                                       location[2], quantity_id), 3)
                 self.buildQuantityRow(m, femFun, quantity_id, quantity)
             pointGaugesVec = PETSc.Vec().create(comm=PETSc.COMM_SELF)
@@ -502,7 +502,7 @@ class Gauges(AV_base):
                     for length_segment in length_segments: print length_segment
                     raise FloatingPointError("Unable to identify next segment while segmenting, are %s in domain?" %
                                              str(endpoints))
-                log("Identified best segment of length %g on %d: %s" % (segment_length, proc_rank, str(segment)), 9)
+                logEvent("Identified best segment of length %g on %d: %s" % (segment_length, proc_rank, str(segment)), 9)
                 selected_segments[proc_rank].append(segment)
                 segment_pos += segment_length
 
@@ -510,11 +510,11 @@ class Gauges(AV_base):
             if err > 1e-8:
                 msg = "Segmented line %s different from original length by ratio %e\n segments: %s" % (
                     str(endpoints), err, str(selected_segments))
-                log(msg, 3)
+                logEvent(msg, 3)
                 if err > 10*eps:
                     raise FloatingPointError(msg)
 
-        log("Selected segments: %s" % str(selected_segments), 9)
+        logEvent("Selected segments: %s" % str(selected_segments), 9)
         segments = comm.scatter(selected_segments)
         return segments
 
@@ -650,10 +650,10 @@ class Gauges(AV_base):
         if self.isPointGauge or self.isLineGauge:
             self.localQuantitiesBuf = np.concatenate([gaugesVec.getArray() for gaugesVec in
                                                       self.pointGaugeVecs]).astype(np.double)
-            log("Sending local array of type %s and shape %s to root on comm %s" % (
+            logEvent("Sending local array of type %s and shape %s to root on comm %s" % (
                 str(self.localQuantitiesBuf.dtype), str(self.localQuantitiesBuf.shape), str(self.gaugeComm)), 9)
             if self.gaugeComm.rank == 0:
-                log("Receiving global array of type %s and shape %s on comm %s" % (
+                logEvent("Receiving global array of type %s and shape %s on comm %s" % (
                 str(self.localQuantitiesBuf.dtype), str(self.globalQuantitiesBuf.shape), str(self.gaugeComm)), 9)
             self.gaugeComm.Gatherv(sendbuf=[self.localQuantitiesBuf, MPI.DOUBLE],
                                    recvbuf=[self.globalQuantitiesBuf, (self.globalQuantitiesCounts, None),
@@ -687,7 +687,7 @@ class Gauges(AV_base):
             return
 
         time = self.get_time()
-        log("Calculate called at time %g" % time)
+        logEvent("Calculate called at time %g" % time)
         # check that gauge is in its active time region
         if self.activeTime is not None and (self.activeTime[0] > time or self.activeTime[1] < time):
             return

--- a/proteus/InputTranslators.py
+++ b/proteus/InputTranslators.py
@@ -5,8 +5,8 @@ Classes for taking input in other formats
    :parts: 1
 """
 from proteus.EGeometry import *
-def logEvent(string):
-    print string
+from .Profiling import logEvent
+
 class GF:
     """
     Read a file from the vessel database an set up in a domain.

--- a/proteus/LatexReport.py
+++ b/proteus/LatexReport.py
@@ -6,6 +6,8 @@ Class and script for generating a report from simulation data.
    :parts: 1
 """
 
+from .Profiling import logEvent
+
 def openLatexReport(filename,reportname):
     latexReport = open(filename,'w')
     latexReport.write(r"""\documentclass{amsart}

--- a/proteus/LinearAlgebraTools.py
+++ b/proteus/LinearAlgebraTools.py
@@ -13,7 +13,7 @@ representations using PETSc.
 import numpy
 import math
 from .superluWrappers import *
-from Profiling import logEvent
+from .Profiling import logEvent
 from petsc4py import PETSc as p4pyPETSc
 from . import flcbdfWrappers
 

--- a/proteus/LinearSolvers.py
+++ b/proteus/LinearSolvers.py
@@ -9,7 +9,7 @@ import lapackWrappers
 import superluWrappers
 from petsc4py import PETSc as p4pyPETSc
 from math import *
-from Profiling import logEvent
+from .Profiling import logEvent
 
 class LinearSolver:
     """

--- a/proteus/MeshTools.py
+++ b/proteus/MeshTools.py
@@ -9,7 +9,7 @@ import numpy as np
 import array
 from Archiver import *
 from LinearAlgebraTools import ParVec_petsc4py
-from Profiling import logEvent,memory
+from .Profiling import logEvent,memory
 
 class Node:
     """A numbered point in 3D Euclidean space
@@ -577,13 +577,13 @@ class Mesh:
         import flcbdfWrappers
         comm = Comm.get()
         self.comm=comm
-        log(memory("partitionMesh 1","MeshTools"),level=4)
-        log("Partitioning mesh among %d processors using partitioningType = %d" % (comm.size(),parallelPartitioningType))
+        logEvent(memory("partitionMesh 1","MeshTools"),level=4)
+        logEvent("Partitioning mesh among %d processors using partitioningType = %d" % (comm.size(),parallelPartitioningType))
         self.subdomainMesh=self.__class__()
         self.subdomainMesh.globalMesh = self
         self.subdomainMesh.cmesh=cmeshTools.CMesh()
         self.nLayersOfOverlap = nLayersOfOverlap; self.parallelPartitioningType = parallelPartitioningType
-        log(memory("partitionMesh 2","MeshTools"),level=4)
+        logEvent(memory("partitionMesh 2","MeshTools"),level=4)
         if parallelPartitioningType == MeshParallelPartitioningTypes.node:
             #mwf for now always gives 1 layer of overlap
             (self.elementOffsets_subdomain_owned,
@@ -612,7 +612,7 @@ class Mesh:
              self.edgeNumbering_subdomain2global,
              self.edgeNumbering_global2original) = flcbdfWrappers.partitionElements(nLayersOfOverlap,self.cmesh,self.subdomainMesh.cmesh)
         #
-        log(memory("partitionMesh 3","MeshTools"),level=4)
+        logEvent(memory("partitionMesh 3","MeshTools"),level=4)
         self.subdomainMesh.buildFromC(self.subdomainMesh.cmesh)
         self.subdomainMesh.nElements_owned = self.elementOffsets_subdomain_owned[comm.rank()+1] - self.elementOffsets_subdomain_owned[comm.rank()]
         self.subdomainMesh.nNodes_owned = self.nodeOffsets_subdomain_owned[comm.rank()+1] - self.nodeOffsets_subdomain_owned[comm.rank()]
@@ -620,17 +620,17 @@ class Mesh:
         self.subdomainMesh.nEdges_owned = self.edgeOffsets_subdomain_owned[comm.rank()+1] - self.edgeOffsets_subdomain_owned[comm.rank()]
 
         comm.barrier()
-        log(memory("partitionMesh 4","MeshTools"),level=4)
-        log("Number of Subdomain Elements Owned= "+str(self.subdomainMesh.nElements_owned))
-        log("Number of Subdomain Elements = "+str(self.subdomainMesh.nElements_global))
-        log("Number of Subdomain Nodes Owned= "+str(self.subdomainMesh.nNodes_owned))
-        log("Number of Subdomain Nodes = "+str(self.subdomainMesh.nNodes_global))
-        log("Number of Subdomain elementBoundaries Owned= "+str(self.subdomainMesh.nElementBoundaries_owned))
-        log("Number of Subdomain elementBoundaries = "+str(self.subdomainMesh.nElementBoundaries_global))
-        log("Number of Subdomain Edges Owned= "+str(self.subdomainMesh.nEdges_owned))
-        log("Number of Subdomain Edges = "+str(self.subdomainMesh.nEdges_global))
+        logEvent(memory("partitionMesh 4","MeshTools"),level=4)
+        logEvent("Number of Subdomain Elements Owned= "+str(self.subdomainMesh.nElements_owned))
+        logEvent("Number of Subdomain Elements = "+str(self.subdomainMesh.nElements_global))
+        logEvent("Number of Subdomain Nodes Owned= "+str(self.subdomainMesh.nNodes_owned))
+        logEvent("Number of Subdomain Nodes = "+str(self.subdomainMesh.nNodes_global))
+        logEvent("Number of Subdomain elementBoundaries Owned= "+str(self.subdomainMesh.nElementBoundaries_owned))
+        logEvent("Number of Subdomain elementBoundaries = "+str(self.subdomainMesh.nElementBoundaries_global))
+        logEvent("Number of Subdomain Edges Owned= "+str(self.subdomainMesh.nEdges_owned))
+        logEvent("Number of Subdomain Edges = "+str(self.subdomainMesh.nEdges_global))
         comm.barrier()
-        log("Finished partitioning")
+        logEvent("Finished partitioning")
         par_nodeDiametersArray = ParVec_petsc4py(self.subdomainMesh.nodeDiametersArray,
                                                  bs=1,
                                                  n=self.subdomainMesh.nNodes_owned,
@@ -641,10 +641,10 @@ class Mesh:
         # comm.beginSequential()
         # from Profiling import memory
         # memory()
-        # log(memory("Partitioning Mesh","Mesh"),level=1)
+        # logEvent(memory("Partitioning Mesh","Mesh"),level=1)
         # del self.cmesh
         # #cmeshTools.deleteMeshDataStructures(self.cmesh)
-        # log(memory("Without global mesh","Mesh"),level=1)
+        # logEvent(memory("Without global mesh","Mesh"),level=1)
         # comm.endSequential()
     def partitionMeshFromFiles(self,filebase,base,nLayersOfOverlap=1,parallelPartitioningType=MeshParallelPartitioningTypes.element):
         import cmeshTools
@@ -652,13 +652,13 @@ class Mesh:
         import flcbdfWrappers
         comm = Comm.get()
         self.comm=comm
-        log(memory("partitionMesh 1","MeshTools"),level=4)
-        log("Partitioning mesh among %d processors using partitioningType = %d" % (comm.size(),parallelPartitioningType))
+        logEvent(memory("partitionMesh 1","MeshTools"),level=4)
+        logEvent("Partitioning mesh among %d processors using partitioningType = %d" % (comm.size(),parallelPartitioningType))
         self.subdomainMesh=self.__class__()
         self.subdomainMesh.globalMesh = self
         self.subdomainMesh.cmesh=cmeshTools.CMesh()
         self.nLayersOfOverlap = nLayersOfOverlap; self.parallelPartitioningType = parallelPartitioningType
-        log(memory("partitionMesh 2","MeshTools"),level=4)
+        logEvent(memory("partitionMesh 2","MeshTools"),level=4)
         if parallelPartitioningType == MeshParallelPartitioningTypes.node:
             #mwf for now always gives 1 layer of overlap
             (self.elementOffsets_subdomain_owned,
@@ -687,7 +687,7 @@ class Mesh:
              self.edgeNumbering_subdomain2global,
              self.edgeNumbering_global2original) = flcbdfWrappers.partitionElementsFromTetgenFiles(filebase,base,nLayersOfOverlap,self.cmesh,self.subdomainMesh.cmesh)
         #
-        log(memory("partitionMesh 3","MeshTools"),level=4)
+        logEvent(memory("partitionMesh 3","MeshTools"),level=4)
         self.buildFromCNoArrays(self.cmesh)
         self.subdomainMesh.buildFromC(self.subdomainMesh.cmesh)
         self.subdomainMesh.nElements_owned = self.elementOffsets_subdomain_owned[comm.rank()+1] - self.elementOffsets_subdomain_owned[comm.rank()]
@@ -696,17 +696,17 @@ class Mesh:
         self.subdomainMesh.nEdges_owned = self.edgeOffsets_subdomain_owned[comm.rank()+1] - self.edgeOffsets_subdomain_owned[comm.rank()]
 
         comm.barrier()
-        log(memory("partitionMesh 4","MeshTools"),level=4)
-        log("Number of Subdomain Elements Owned= "+str(self.subdomainMesh.nElements_owned))
-        log("Number of Subdomain Elements = "+str(self.subdomainMesh.nElements_global))
-        log("Number of Subdomain Nodes Owned= "+str(self.subdomainMesh.nNodes_owned))
-        log("Number of Subdomain Nodes = "+str(self.subdomainMesh.nNodes_global))
-        log("Number of Subdomain elementBoundaries Owned= "+str(self.subdomainMesh.nElementBoundaries_owned))
-        log("Number of Subdomain elementBoundaries = "+str(self.subdomainMesh.nElementBoundaries_global))
-        log("Number of Subdomain Edges Owned= "+str(self.subdomainMesh.nEdges_owned))
-        log("Number of Subdomain Edges = "+str(self.subdomainMesh.nEdges_global))
+        logEvent(memory("partitionMesh 4","MeshTools"),level=4)
+        logEvent("Number of Subdomain Elements Owned= "+str(self.subdomainMesh.nElements_owned))
+        logEvent("Number of Subdomain Elements = "+str(self.subdomainMesh.nElements_global))
+        logEvent("Number of Subdomain Nodes Owned= "+str(self.subdomainMesh.nNodes_owned))
+        logEvent("Number of Subdomain Nodes = "+str(self.subdomainMesh.nNodes_global))
+        logEvent("Number of Subdomain elementBoundaries Owned= "+str(self.subdomainMesh.nElementBoundaries_owned))
+        logEvent("Number of Subdomain elementBoundaries = "+str(self.subdomainMesh.nElementBoundaries_global))
+        logEvent("Number of Subdomain Edges Owned= "+str(self.subdomainMesh.nEdges_owned))
+        logEvent("Number of Subdomain Edges = "+str(self.subdomainMesh.nEdges_global))
         comm.barrier()
-        log("Finished partitioning")
+        logEvent("Finished partitioning")
         par_nodeDiametersArray = ParVec_petsc4py(self.subdomainMesh.nodeDiametersArray,
                                                  bs=1,
                                                  n=self.subdomainMesh.nNodes_owned,
@@ -717,10 +717,10 @@ class Mesh:
         # comm.beginSequential()
         # from Profiling import memory
         # memory()
-        # log(memory("Partitioning Mesh","Mesh"),level=1)
+        # logEvent(memory("Partitioning Mesh","Mesh"),level=1)
         # del self.cmesh
         # #cmeshTools.deleteMeshDataStructures(self.cmesh)
-        # log(memory("Without global mesh","Mesh"),level=1)
+        # logEvent(memory("Without global mesh","Mesh"),level=1)
         # comm.endSequential()
     def writeMeshXdmf(self,ar,name='',t=0.0,init=False,meshChanged=False,Xdmf_ElementTopology="Triangle",tCount=0, EB=False):
         if self.arGridCollection != None:
@@ -995,7 +995,7 @@ class Mesh:
     def buildFromC(self,cmesh):
         import cmeshTools
         #
-        log(memory("buildFromC","MeshTools"),level=4)
+        logEvent(memory("buildFromC","MeshTools"),level=4)
         self.cmesh = cmesh
         (self.nElements_global,
          self.nNodes_global,
@@ -1049,11 +1049,11 @@ class Mesh:
         self.nElements_owned = self.nElements_global
         self.nElementBoundaries_owned = self.nElementBoundaries_global
         self.nEdges_owned = self.nEdges_global
-        log(memory("buildFromC","MeshTools"),level=4)
+        logEvent(memory("buildFromC","MeshTools"),level=4)
     def buildFromCNoArrays(self,cmesh):
         import cmeshTools
         #
-        log(memory("buildFromC","MeshTools"),level=4)
+        logEvent(memory("buildFromC","MeshTools"),level=4)
         self.cmesh = cmesh
         (self.nElements_global,
          self.nNodes_global,
@@ -1071,7 +1071,7 @@ class Mesh:
          self.sigmaMax,
          self.volume) = cmeshTools.buildPythonMeshInterfaceNoArrays(self.cmesh)
         self.hasGeometricInfo = False
-        log(memory("buildFromCNoArrays","MeshTools"),level=4)
+        logEvent(memory("buildFromCNoArrays","MeshTools"),level=4)
     def buildNodeStarArrays(self):
         if self.nodeStarArray == None:
             #cek old
@@ -2091,10 +2091,10 @@ class MultilevelRectangularGrid(MultilevelMesh):
         self.refineFactorList=[EVec(0,0,0)]
         self.meshList.append(RectangularGrid(nx,ny,nz,Lx,Ly,Lz))
         self.elementChildren = []
-        log(self.meshList[0].meshInfo())
+        logEvent(self.meshList[0].meshInfo())
         for l in range(1,refinementLevels+1):
             self.refine()
-            log(self.meshList[-1].meshInfo())
+            logEvent(self.meshList[-1].meshInfo())
 
     def refine():
         self.meshList.append(RectangularMesh())
@@ -2288,7 +2288,7 @@ class TetrahedralMesh(Mesh):
         self.boundaryNodes=set()
         self.interiorEdges=set()
         self.interiorNodes=set()
-        log("Building triangle,edge, and node maps")
+        logEvent("Building triangle,edge, and node maps")
         for T in self.tetrahedronList:
             for localTriangleNumber,t in enumerate(T.triangles):
                 self.triangleMap[t.N].append((T.N,localTriangleNumber))
@@ -2296,17 +2296,17 @@ class TetrahedralMesh(Mesh):
                 self.edgeMap[e.N].append((T.N,localEdgeNumber))
             for localNodeNumber,n in enumerate(T.nodes):
                 self.nodeMap[n.N].append((T.N,localNodeNumber))
-        log("Extracting boundary and interior triangles")
+        logEvent("Extracting boundary and interior triangles")
         for tN,etList in enumerate(self.triangleMap):
             if len(etList) == 1:
                 self.boundaryTriangles.add(self.triangleList[tN])
             else:
                 self.interiorTriangles.add(self.triangleList[tN])
-        log("Extracting boundary edges and nodes")
+        logEvent("Extracting boundary edges and nodes")
         for t in self.boundaryTriangles:
             self.boundaryEdges.update(t.edges)
             self.boundaryNodes.update(t.nodes)
-        log("Extracting interior edges and nodes")
+        logEvent("Extracting interior edges and nodes")
         for t in self.interiorTriangles:
             self.interiorEdges.update(t.edges)
             self.interiorNodes.update(t.nodes)
@@ -2350,13 +2350,13 @@ class TetrahedralMesh(Mesh):
         meshIn = open(filename+'.3dm','r')
         firstLine = meshIn.readline()
         firstWords = firstLine.split()
-        log("Reading object=%s from file=%s" % (firstWords[0],filename))
+        logEvent("Reading object=%s from file=%s" % (firstWords[0],filename))
         line = meshIn.readline()
         columns = line.split()
         tets = []
         tetEdges=set()
         tetTriangles=set()
-        log("Reading "+`filename`+" and building node lists for tetrahedra,triangles, and edges")
+        logEvent("Reading "+`filename`+" and building node lists for tetrahedra,triangles, and edges")
         #assume test are ordered by tet number
         while (columns[0] == 'E4T'):
             nodeNumbers = [int(c) - adhBase for c in columns[2:6]]
@@ -2550,7 +2550,7 @@ class TetrahedralMesh(Mesh):
         return childrenDict
 
     def refineFreudenthalBey(self,oldMesh):
-        log("Refining the mesh using Freudenthal-Bey refinement")
+        logEvent("Refining the mesh using Freudenthal-Bey refinement")
         childrenDict={}
         for T in oldMesh.tetrahedronDict.values():
             #deep copy old nodes because we'll renumber
@@ -2658,19 +2658,19 @@ class TetrahedralMesh(Mesh):
 
     def generateFromTetgenFiles(self,filebase,base,skipGeometricInit=True,parallel=False):
         import cmeshTools
-        log(memory("declaring CMesh"),level=4)
+        logEvent(memory("declaring CMesh"),level=4)
         self.cmesh = cmeshTools.CMesh()
-        log(memory("Initializing CMesh"),level=4)
+        logEvent(memory("Initializing CMesh"),level=4)
         if parallel:
             cmeshTools.generateFromTetgenFilesParallel(self.cmesh,filebase,base)
         else:
             cmeshTools.generateFromTetgenFiles(self.cmesh,filebase,base)
-        log(memory("calling cmeshTools.generateFromTetgenFiles","cmeshTools"),level=4)
+        logEvent(memory("calling cmeshTools.generateFromTetgenFiles","cmeshTools"),level=4)
         if skipGeometricInit == False:
             cmeshTools.allocateGeometricInfo_tetrahedron(self.cmesh)
             cmeshTools.computeGeometricInfo_tetrahedron(self.cmesh)
         self.buildFromC(self.cmesh)
-        log(memory("calling buildFromC"),level=4)
+        logEvent(memory("calling buildFromC"),level=4)
     def generateFrom3DMFile(self,filebase,base=1):
         import cmeshTools
         self.cmesh = cmeshTools.CMesh()
@@ -2806,7 +2806,7 @@ class HexahedralMesh(Mesh):
         self.boundaryNodes=set()
         self.interiorEdges=set()
         self.interiorNodes=set()
-        log("Building triangle,edge, and node maps")
+        logEvent("Building triangle,edge, and node maps")
         for T in self.elemList:
             for localFaceNumber,t in enumerate(T.faces):
                 self.faceMap[t.N].append((T.N,localFaceNumber))
@@ -2814,17 +2814,17 @@ class HexahedralMesh(Mesh):
                 self.edgeMap[e.N].append((T.N,localEdgeNumber))
             for localNodeNumber,n in enumerate(T.nodes):
                 self.nodeMap[n.N].append((T.N,localNodeNumber))
-        log("Extracting boundary and interior triangles")
+        logEvent("Extracting boundary and interior triangles")
         for tN,etList in enumerate(self.faceMap):
             if len(etList) == 1:
                 self.boundaryFaces.add(self.faceList[tN])
             else:
                 self.interiorFaces.add(self.faceList[tN])
-        log("Extracting boundary edges and nodes")
+        logEvent("Extracting boundary edges and nodes")
         for t in self.boundaryTriangles:
             self.boundaryEdges.update(t.edges)
             self.boundaryNodes.update(t.nodes)
-        log("Extracting interior edges and nodes")
+        logEvent("Extracting interior edges and nodes")
         for t in self.interiorTriangles:
             self.interiorEdges.update(t.edges)
             self.interiorNodes.update(t.nodes)
@@ -2895,7 +2895,7 @@ class Mesh2DM(Mesh):
         meshIn = open(filename+'.3dm','r')
         firstLine = meshIn.readline()
         firstWords = firstLine.split()
-        log("Reading object=%s from file=%s" % (firstWords[0],filename))
+        logEvent("Reading object=%s from file=%s" % (firstWords[0],filename))
         line = meshIn.readline()
         columns = line.split()
         #read in the tetrahedra and nodes as memory-efficiently as possible
@@ -3570,7 +3570,7 @@ class MultilevelTetrahedralMesh(MultilevelMesh):
         MultilevelMesh.__init__(self)
         self.useC = True
         self.nLayersOfOverlap = nLayersOfOverlap; self.parallelPartitioningType = parallelPartitioningType
-        log("Generating tetrahedral mesh")
+        logEvent("Generating tetrahedral mesh")
         if not skipInit:
             if self.useC:
                 self.meshList.append(TetrahedralMesh())
@@ -3594,10 +3594,10 @@ class MultilevelTetrahedralMesh(MultilevelMesh):
                 self.meshList[0].nodeArray[:,1] += y
                 self.meshList[0].nodeArray[:,2] += z
                 self.elementChildren=[]
-                log(self.meshList[0].meshInfo())
+                logEvent(self.meshList[0].meshInfo())
                 for l in range(1,refinementLevels):
                     self.refine()
-                    log(self.meshList[-1].meshInfo())
+                    logEvent(self.meshList[-1].meshInfo())
                 self.buildArrayLists()
     def generateFromExistingCoarseMesh(self,mesh0,refinementLevels,nLayersOfOverlap=1,
                                        parallelPartitioningType=MeshParallelPartitioningTypes.element):
@@ -3609,11 +3609,11 @@ class MultilevelTetrahedralMesh(MultilevelMesh):
         self.cmultilevelMesh = None
         if self.useC:
             self.meshList.append(mesh0)
-            log("cmeshTools.CMultilevelMesh")
+            logEvent("cmeshTools.CMultilevelMesh")
             self.cmultilevelMesh = cmeshTools.CMultilevelMesh(self.meshList[0].cmesh,refinementLevels)
-            log("buildFromC")
+            logEvent("buildFromC")
             self.buildFromC(self.cmultilevelMesh)
-            log("partitionMesh")
+            logEvent("partitionMesh")
             self.meshList[0].partitionMesh(nLayersOfOverlap=nLayersOfOverlap,parallelPartitioningType=parallelPartitioningType)
             for l in range(1,refinementLevels):
                 self.meshList.append(TetrahedralMesh())
@@ -3626,11 +3626,11 @@ class MultilevelTetrahedralMesh(MultilevelMesh):
             self.meshList[0].rectangularToTetrahedral(grid)
             self.meshList[0].subdomainMesh = self.meshList[0]
             self.elementChildren=[]
-            log(self.meshList[0].meshInfo())
+            logEvent(self.meshList[0].meshInfo())
             for l in range(1,refinementLevels):
                 self.refine()
                 self.meshList[l].subdomainMesh = self.meshList[l]
-                log(self.meshList[-1].meshInfo())
+                logEvent(self.meshList[-1].meshInfo())
             self.buildArrayLists()
     def generatePartitionedMeshFromTetgenFiles(self,filebase,base,mesh0,refinementLevels,nLayersOfOverlap=1,
                                                parallelPartitioningType=MeshParallelPartitioningTypes.node):
@@ -3645,11 +3645,11 @@ class MultilevelTetrahedralMesh(MultilevelMesh):
         self.elementParents = None
         self.cmultilevelMesh = None
         self.meshList.append(mesh0)
-        log("cmeshTools.CMultilevelMesh")
+        logEvent("cmeshTools.CMultilevelMesh")
         self.cmultilevelMesh = cmeshTools.CMultilevelMesh(self.meshList[0].cmesh,refinementLevels)
-        log("buildFromC")
+        logEvent("buildFromC")
         self.buildFromC(self.cmultilevelMesh)
-        log("partitionMesh")
+        logEvent("partitionMesh")
         self.meshList[0].partitionMeshFromFiles(filebase,base,nLayersOfOverlap=nLayersOfOverlap,parallelPartitioningType=parallelPartitioningType)
     def refine(self):
         self.meshList.append(TetrahedralMesh())
@@ -3678,7 +3678,7 @@ class MultilevelHexahedralMesh(MultilevelMesh):
         else:
             self.useC = False
         self.nLayersOfOverlap = nLayersOfOverlap; self.parallelPartitioningType = parallelPartitioningType
-        log("Generating hexahedral mesh")
+        logEvent("Generating hexahedral mesh")
         if not skipInit:
             if self.useC:
                 self.meshList.append(HexahedralMesh())
@@ -3699,11 +3699,11 @@ class MultilevelHexahedralMesh(MultilevelMesh):
                 self.meshList.append(HexahedralMesh())
                 self.elementChildren=[]
                 self.meshList[0].sigmaMax=0.0
-                log(self.meshList[0].meshInfo())
+                logEvent(self.meshList[0].meshInfo())
                 for l in range(1,refinementLevels):
                     self.refine()
                     self.meshList[-1].sigmaMax=0.0
-                    log(self.meshList[-1].meshInfo())
+                    logEvent(self.meshList[-1].meshInfo())
                 self.buildArrayLists()
     def generateFromExistingCoarseMesh(self,mesh0,refinementLevels,nLayersOfOverlap=1,
                                        parallelPartitioningType=MeshParallelPartitioningTypes.element):
@@ -4064,7 +4064,7 @@ class TriangularMesh(Mesh):
         return childrenDict
 
     def refineFreudenthalBey(self,oldMesh):
-        log("Refining the mesh using Freudenthal-Bey refinement")
+        logEvent("Refining the mesh using Freudenthal-Bey refinement")
         childrenDict={}
         for t in oldMesh.triangleDict.values():
             #deep copy old nodes because we'll renumber
@@ -4128,7 +4128,7 @@ Number of nodes : %d\n""" % (self.nElements_global,
         columns = line.split()
         triangles = []
         triangleEdges=set()
-        log("Reading "+`filename`+ \
+        logEvent("Reading "+`filename`+ \
                 " and building node lists for triangles, and edges")
         #assume triangles are ordered by triangle number
         while (columns[0] == 'E3T'):
@@ -4479,7 +4479,7 @@ Number of nodes : %d\n""" % (self.nElements_global,
         return node
 
     def refine(self,oldMesh):
-        log("Refining Using Standard Quadrilateral Refinement")
+        logEvent("Refining Using Standard Quadrilateral Refinement")
         import pdb
 #        pdb.set_trace()
         childrenDict={}
@@ -4616,11 +4616,11 @@ class MultilevelTriangularMesh(MultilevelMesh):
                 self.meshList[0].nodeArray[:,2] += z
                 self.meshList[0].subdomainMesh = self.meshList[0]
                 self.elementChildren=[]
-                log(self.meshList[0].meshInfo())
+                logEvent(self.meshList[0].meshInfo())
                 for l in range(1,refinementLevels):
                     self.refine()
                     self.meshList[l].subdomainMesh = self.meshList[l]
-                    log(self.meshList[-1].meshInfo())
+                    logEvent(self.meshList[-1].meshInfo())
                 self.buildArrayLists()
     #
     #mwf what's the best way to build from an existing mesh
@@ -4648,11 +4648,11 @@ class MultilevelTriangularMesh(MultilevelMesh):
             self.meshList[0].rectangularToTriangular(grid)
             self.meshList[0].subdomainMesh = self.meshList[0]
             self.elementChildren=[]
-            log(self.meshList[0].meshInfo())
+            logEvent(self.meshList[0].meshInfo())
             for l in range(1,refinementLevels):
                 self.refine()
                 self.meshList[l].subdomainMesh = self.meshList[l]
-                log(self.meshList[-1].meshInfo())
+                logEvent(self.meshList[-1].meshInfo())
             self.buildArrayLists()
 
     def refine(self):
@@ -4668,14 +4668,14 @@ class MultilevelTriangularMesh(MultilevelMesh):
 
         flagForRefineType = 0 -- newest node, 1 -- 4T, 2 -- U4T
         """
-        log("MultilevelTriangularMesh:locallyRefine")
+        logEvent("MultilevelTriangularMesh:locallyRefine")
         if flagForRefineType == 0:
-            log("MultilevelTriangularMesh: calling cmeshTools.setNewestNodeBases")
+            logEvent("MultilevelTriangularMesh: calling cmeshTools.setNewestNodeBases")
             self.cmeshTools.setNewestNodeBases(2,self.cmultilevelMesh)
         if self.useC:
-            log("MultilevelTriangularMesh: calling locallRefineMultilevelMesh")
+            logEvent("MultilevelTriangularMesh: calling locallRefineMultilevelMesh")
             self.cmeshTools.locallyRefineMultilevelMesh(2,self.cmultilevelMesh,elementTagArray,flagForRefineType)
-            log("MultilevelTriangularMesh: calling buildFromC")
+            logEvent("MultilevelTriangularMesh: calling buildFromC")
             self.buildFromC(self.cmultilevelMesh)
             self.meshList.append(TriangularMesh())
             self.meshList[self.nLevels-1].cmesh = self.cmeshList[self.nLevels-1]
@@ -4709,7 +4709,7 @@ class MultilevelQuadrilateralMesh(MultilevelMesh):
                 self.meshList[0].rectangularToQuadrilateral(grid,x,y,z)
                 self.meshList[0].subdomainMesh = self.meshList[0]
                 self.elementChildren=[]
-                log(self.meshList[0].meshInfo())
+                logEvent(self.meshList[0].meshInfo())
                 self.meshList[0].globalMesh = self.meshList[0]
 
                 # The following four lines should be called elsewhere...Most of this is don in
@@ -4728,7 +4728,7 @@ class MultilevelQuadrilateralMesh(MultilevelMesh):
                 for l in range(1,refinementLevels):
                     self.refine()
                     self.meshList[l].subdomainMesh = self.meshList[l]
-                    log(self.meshList[-1].meshInfo())
+                    logEvent(self.meshList[-1].meshInfo())
                 self.buildArrayLists()
 
     def refine(self):
@@ -4784,13 +4784,13 @@ class InterpolatedBathymetryMesh(MultilevelTriangularMesh):
         self.bathyAssignmentScheme=bathyAssignmentScheme
         self.errorNormType = errorNormType
 
-        log("InterpolatedBathymetryMesh: Calling Triangle to generate 2D coarse mesh for "+self.domain.name)
+        logEvent("InterpolatedBathymetryMesh: Calling Triangle to generate 2D coarse mesh for "+self.domain.name)
         tmesh = TriangleTools.TriangleBaseMesh(baseFlags=self.triangleOptions,
                                                nbase=1,
                                                verbose=10)
         tmesh.readFromPolyFile(domain.polyfile)
 
-        log("InterpolatedBathymetryMesh: Converting to Proteus Mesh")
+        logEvent("InterpolatedBathymetryMesh: Converting to Proteus Mesh")
         self.coarseMesh=tmesh.convertToProteusMesh(verbose=1)
         MultilevelTriangularMesh.__init__(self,0,0,0,skipInit=True,nLayersOfOverlap=0,
                                           parallelPartitioningType=MeshParallelPartitioningTypes.element)
@@ -4799,7 +4799,7 @@ class InterpolatedBathymetryMesh(MultilevelTriangularMesh):
         self.computeGeometricInfo()
         print self.meshList[-1].volume
         #allocate some arrays based on the bathymetry data
-        log("InterpolatedBathymetryMesh:Allocating data structures for bathymetry interpolation algorithm")
+        logEvent("InterpolatedBathymetryMesh:Allocating data structures for bathymetry interpolation algorithm")
         if bathyType == "points":
             self.nPoints_global = self.domain.bathy.shape[0]
             self.pointElementsArray_old = -np.ones((self.nPoints_global,),'i')
@@ -4818,27 +4818,27 @@ class InterpolatedBathymetryMesh(MultilevelTriangularMesh):
             self.bathyInterpolant = scipy_interpolate.RectBivariateSpline(x,y,z,kx=1,ky=1)
             #self.bathyInterpolant = scipy_interpolate.interp2d(x,y,z)
         #
-        log("InterpolatedBathymetryMesh: Locating points on initial mesh")
+        logEvent("InterpolatedBathymetryMesh: Locating points on initial mesh")
         self.locatePoints_initial(self.meshList[-1])
-        log("InterpolatedBathymetryMesh:setting mesh bathymetry from data")
+        logEvent("InterpolatedBathymetryMesh:setting mesh bathymetry from data")
         self.setMeshBathymetry(self.meshList[-1])
-        log("InterpolatedBathymetryMesh: tagging elements for refinement")
+        logEvent("InterpolatedBathymetryMesh: tagging elements for refinement")
         self.tagElements(self.meshList[-1])
         levels = 0
         error = 1.0;
         while error >= 1.0 and self.meshList[-1].nNodes_global < self.maxNodes and levels < self.maxLevels:
             levels += 1
-            log("InterpolatedBathymetryMesh: Locally refining, level = %i" % (levels,))
+            logEvent("InterpolatedBathymetryMesh: Locally refining, level = %i" % (levels,))
             self.locallyRefine(self.meshList[-1].elementTags,flagForRefineType=refineType)
-            log("InterpolatedBathymetryMesh: interpolating bathymetry from parent mesh to refined mesh")
+            logEvent("InterpolatedBathymetryMesh: interpolating bathymetry from parent mesh to refined mesh")
             self.interpolateBathymetry()
-            log("InterpolatedBathymetryMesh: Locating points on child mesh")
+            logEvent("InterpolatedBathymetryMesh: Locating points on child mesh")
             self.locatePoints_refined(self.meshList[-1])
-            log("InterpolatedBathymetryMesh: setting mesh bathmetry from data")
+            logEvent("InterpolatedBathymetryMesh: setting mesh bathmetry from data")
             self.setMeshBathymetry(self.meshList[-1])
-            log("InterpolatedBathymetryMesh: tagging elements for refinement")
+            logEvent("InterpolatedBathymetryMesh: tagging elements for refinement")
             error = self.tagElements(self.meshList[-1])
-            log("InterpolatedBathymetryMesh: error = %f atol = %f rtol = %f number of elements tagged = %i" % (error,self.atol,self.rtol,self.meshList[-1].elementTags.sum()))
+            logEvent("InterpolatedBathymetryMesh: error = %f atol = %f rtol = %f number of elements tagged = %i" % (error,self.atol,self.rtol,self.meshList[-1].elementTags.sum()))
 
     def setMeshBathymetry(self,mesh):
         if self.bathyAssignmentScheme == "interpolation":
@@ -5736,7 +5736,7 @@ class MultilevelNURBSMesh(MultilevelMesh):
         MultilevelMesh.__init__(self)
         self.useC = True
         self.nLayersOfOverlap = nLayersOfOverlap; self.parallelPartitioningType = parallelPartitioningType
-        log("Generating NURBS mesh")
+        logEvent("Generating NURBS mesh")
         if not skipInit:
             self.meshList.append(NURBSMesh())
             self.meshList[0].generateNURBSMeshFromRectangularGrid(nx,ny,nz,px,py,pz,Lx,Ly,Lz)

--- a/proteus/NonlinearSolvers.py
+++ b/proteus/NonlinearSolvers.py
@@ -11,9 +11,7 @@ from math import *
 import math #to disambiguate math.log and log
 from LinearAlgebraTools import *
 from LinearSolvers import *
-from Profiling import *
-
-log = logEvent
+from .Profiling import *
 
 #mwf hack for Eikonal equation solvers
 import FemTools
@@ -211,7 +209,7 @@ class NonlinearSolver:
                 if self.norm_r < self.lastNorm_r:
                     self.ratio_r_current = self.norm_r/self.lastNorm_r
                 else:
-                    log("residual increase %s" % self.norm_r)
+                    logEvent("residual increase %s" % self.norm_r)
                     self.convergingIts=0
                     self.ratio_r_solve = 1.0
                     self.ratio_du_solve = 1.0
@@ -221,7 +219,7 @@ class NonlinearSolver:
                 if self.ratio_r_current > 1.0e-100:
                     log_ratio_r_current = math.log(self.ratio_r_current)
                 else:
-                    log("log(ratio_r) too small ratio_r = %12.5e" % self.ratio_r_current)
+                    logEvent("log(ratio_r) too small ratio_r = %12.5e" % self.ratio_r_current)
                     self.convergingIts=0
                     self.ratio_r_solve = 1.0
                     self.ratio_du_solve = 1.0
@@ -236,7 +234,7 @@ class NonlinearSolver:
                     if self.norm_du < self.lastNorm_du:
                         ratio_du_current = self.norm_du/self.lastNorm_du
                     else:
-                        log("du increase norm(du_last)=%12.5e, norm(du)=%12.5e, its=%d, convergingIts=%d" % (self.lastNorm_du,self.norm_du,self.its,self.convergingIts))
+                        logEvent("du increase norm(du_last)=%12.5e, norm(du)=%12.5e, its=%d, convergingIts=%d" % (self.lastNorm_du,self.norm_du,self.its,self.convergingIts))
                         self.convergingIts=0
                         self.ratio_r_solve = 1.0
                         self.ratio_du_solve = 1.0
@@ -246,7 +244,7 @@ class NonlinearSolver:
                     if ratio_du_current > 1.0e-100:
                         log_ratio_du_current = math.log(ratio_du_current)
                     else:
-                        log("log(du ratio) too small to calculate ratio_du=%12.5e" % ratio_du_current)
+                        logEvent("log(du ratio) too small to calculate ratio_du=%12.5e" % ratio_du_current)
                         self.convergingIts=0
                         self.ratio_r_solve = 1.0
                         self.ratio_du_solve = 1.0
@@ -302,7 +300,7 @@ class NonlinearSolver:
             self.solveCalls_failed +=1
             self.recordedIts_failed +=self.its
             self.failedFlag = True
-            log("   Newton it %d == maxIts FAILED convergenceTest = %s" % (self.its,self.convergenceTest))
+            logEvent("   Newton it %d == maxIts FAILED convergenceTest = %s" % (self.its,self.convergenceTest))
         else:
             self.its+=1
             self.convergingIts+=1
@@ -418,18 +416,18 @@ class Newton(NonlinearSolver):
             etaMin = 0.0001
         else:
             etaMin = 0.0001*(self.rtol_r*self.norm_r0 + self.atol_r)/self.norm_r
-        log("etaMin "+`etaMin`)
+        logEvent("etaMin "+`etaMin`)
         if self.its > 1:
             etaA = gamma * self.norm_r**2/self.norm_r_last**2
-            log("etaA "+`etaA`)
-            log("gama*self.etaLast**2 "+ `gamma*self.etaLast**2`)
+            logEvent("etaA "+`etaA`)
+            logEvent("gama*self.etaLast**2 "+ `gamma*self.etaLast**2`)
             if gamma*self.etaLast**2 < 0.1:
                 etaC = min(etaMax,etaA)
             else:
                 etaC = min(etaMax,max(etaA,gamma*self.etaLast**2))
         else:
             etaC = etaMax
-        log("etaC "+`etaC`)
+        logEvent("etaC "+`etaC`)
         eta = min(etaMax,max(etaC,etaMin))
         self.etaLast = eta
         self.norm_r_last = self.norm_r
@@ -465,13 +463,13 @@ class Newton(NonlinearSolver):
         self.linearSolverFailed = False
         while (not self.converged(r) and
                not self.failed()):
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
                 % (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
                 self.F.getJacobian(self.J)
                 if self.linearSolver.computeEigenvalues:
-                    log("Calculating eigenvalues of J^t J")
+                    logEvent("Calculating eigenvalues of J^t J")
                     self.JLast[:]=self.J
                     self.J_t_J[:]=self.J
                     self.J_t_J *= numpy.transpose(self.J)
@@ -480,7 +478,7 @@ class Newton(NonlinearSolver):
                     try:
                         self.norm_2_Jinv_current = 1.0/sqrt(min(self.JLsolver.eigenvalues_r))
                     except:
-                        log("Norm of J_inv_current is singular to machine prection 1/sqrt("+`min(self.JLsolver.eigenvalues_r)`+")")
+                        logEvent("Norm of J_inv_current is singular to machine prection 1/sqrt("+`min(self.JLsolver.eigenvalues_r)`+")")
                         self.norm_2_Jinv_current = np.inf
                     self.kappa_current = self.norm_2_J_current*self.norm_2_Jinv_current
                     self.betaK_current = self.norm_2_Jinv_current
@@ -506,7 +504,7 @@ class Newton(NonlinearSolver):
             #print "global r",r
             if self.linearSolver.computeEigenvalues:
                 #approximate Lipschitz constant of J
-                log("Calculating eigenvalues of dJ^t dJ")
+                logEvent("Calculating eigenvalues of dJ^t dJ")
                 self.F.getJacobian(self.dJ_t_dJ)
                 self.dJ_t_dJ-=self.JLast
                 self.dJ_t_dJ *= numpy.transpose(self.dJ_t_dJ)
@@ -569,12 +567,12 @@ class Newton(NonlinearSolver):
                             else:
                                 par_r.scatter_forward_insert()
                         norm_r_cur = self.norm(r)
-                        log("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
+                        logEvent("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
                                                                                norm_r_cur,
                                                                                self.atol_r,
                                                                                self.rtol_r))
                     if ls_its > 0:
-                        log("Linesearches = %i" % ls_its,level=3)
+                        logEvent("Linesearches = %i" % ls_its,level=3)
         else:
             if self.linearSolver.computeEigenvalues:
                 try:
@@ -622,13 +620,13 @@ class Newton(NonlinearSolver):
                     Viewers.newPlot()
                     Viewers.newWindow()
                 #raw_input("wait")
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
                 % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
-            log(memory("Newton","Newton"),level=4)
+            logEvent(memory("Newton","Newton"),level=4)
             return self.failedFlag
-        log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+        logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
             % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
-        log(memory("Newton","Newton"),level=4)
+        logEvent(memory("Newton","Newton"),level=4)
 
 import deim_utils
 class POD_Newton(Newton):
@@ -717,7 +715,7 @@ class POD_Newton(Newton):
         self.linearSolverFailed = False
         while (not self.converged(pod_r) and
                not self.failed()):
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
                 % (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
@@ -746,10 +744,10 @@ class POD_Newton(Newton):
             pod_r[:] = np.dot(self.U_transpose,r)
             r[:] = np.dot(self.U,pod_r)
         else:
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
                 % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
             return self.failedFlag
-        log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+        logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
             % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
 
 class POD_DEIM_Newton(Newton):
@@ -902,7 +900,7 @@ class POD_DEIM_Newton(Newton):
         self.linearSolverFailed = False
         while (not self.converged(pod_r) and
                not self.failed()):
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
                 % (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
@@ -931,10 +929,10 @@ class POD_DEIM_Newton(Newton):
             pod_r[:] = np.dot(self.U_transpose,r)
             r[:] = np.dot(self.U,pod_r)
         else:
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
                 % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
             return self.failedFlag
-        log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+        logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
             % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
     def solveDEIM(self,u,r=None,b=None,par_u=None,par_r=None):
         """
@@ -973,7 +971,7 @@ class POD_DEIM_Newton(Newton):
         self.linearSolverFailed = False
         while (not self.converged(pod_r) and
                not self.failed()):
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %g test=%s"
                 % (self.its-1,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r)),self.convergenceTest),level=1)
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
@@ -1059,10 +1057,10 @@ class POD_DEIM_Newton(Newton):
             assert not numpy.isnan(pod_r).any()
             r[:] = np.dot(self.U,pod_r)
         else:
-            log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+            logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
                 % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
             return self.failedFlag
-        log("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
+        logEvent("   Newton it %d norm(r) = %12.5e  \t\t norm(r)/(rtol*norm(r0)+atol) = %12.5e"
             % (self.its,self.norm_r,(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
 
 
@@ -1208,18 +1206,18 @@ class NewtonNS(NonlinearSolver):
         self.linearSolverFailed = False
         while (not self.converged(r) and
                not self.failed()):
-            log("   Newton it %d Mom.  norm(r) = %12.5e   tol = %12.5e" % (self.its-1,self.norm_mom_r,self.atol_r),level=1)
-            log("   Newton it %d Cont. norm(r) = %12.5e   tol = %12.5e" % (self.its-1,self.norm_cont_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
+            logEvent("   Newton it %d Mom.  norm(r) = %12.5e   tol = %12.5e" % (self.its-1,self.norm_mom_r,self.atol_r),level=1)
+            logEvent("   Newton it %d Cont. norm(r) = %12.5e   tol = %12.5e" % (self.its-1,self.norm_cont_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
 
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
-                log("Start assembling jacobian",level=4)
+                logEvent("Start assembling jacobian",level=4)
                 self.F.getJacobian(self.J)
-                log("Done  assembling jacobian",level=4)
+                logEvent("Done  assembling jacobian",level=4)
 
                 if self.linearSolver.computeEigenvalues:
 
-                    log("Performing eigen analyses",level=4)
+                    logEvent("Performing eigen analyses",level=4)
                     self.JLast[:]=self.J
                     self.J_t_J[:]=self.J
                     self.J_t_J *= numpy.transpose(self.J)
@@ -1235,7 +1233,7 @@ class NewtonNS(NonlinearSolver):
                 if self.EWtol:
                     self.setLinearSolverTolerance(r)
 
-            log("Start linear solve",level=4)
+            logEvent("Start linear solve",level=4)
             if not self.linearSolverFailed:
                 self.linearSolver.solve(u=self.du,b=r,par_u=self.par_du,par_b=par_r)
                 self.linearSolverFailed = self.linearSolver.failed()
@@ -1319,12 +1317,12 @@ class NewtonNS(NonlinearSolver):
                             par_r.scatter_forward_insert()
                     norm_r_last = norm_r_cur
                     norm_r_cur = self.norm(r)
-                    log("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
+                    logEvent("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
                                                                            norm_r_cur,
                                                                            self.atol_r,
                                                                            self.rtol_r))
                 if ls_its > 0:
-                    log("Linesearches = %i" % ls_its,level=3)
+                    logEvent("Linesearches = %i" % ls_its,level=3)
         else:
             if self.linearSolver.computeEigenvalues:
                 if self.betaK_0*self.etaK_0*self.gammaK_max <= 0.5:
@@ -1369,10 +1367,10 @@ class NewtonNS(NonlinearSolver):
                     Viewers.newPlot()
                     Viewers.newWindow()
 
-        log("   Final       Mom.  norm(r) = %12.5e   %12.5e" % (self.norm_mom_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
-        log("   Final       Cont. norm(r) = %12.5e   %12.5e" % (self.norm_cont_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
+        logEvent("   Final       Mom.  norm(r) = %12.5e   %12.5e" % (self.norm_mom_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
+        logEvent("   Final       Cont. norm(r) = %12.5e   %12.5e" % (self.norm_cont_r,self.rtol_r*self.norm_mom_r0  + self.atol_r),level=1)
 
-        log(memory("NSNewton","NSNewton"),level=4)
+        logEvent(memory("NSNewton","NSNewton"),level=4)
 
 class SSPRKNewton(Newton):
     """
@@ -1441,7 +1439,7 @@ class SSPRKNewton(Newton):
         self.linearSolverFailed = False
         while (not self.converged(r) and
                not self.failed()):
-            log("SSPRKNewton it "+`self.its`+" norm(r) " + `self.norm_r`,level=3)
+            logEvent("SSPRKNewton it "+`self.its`+" norm(r) " + `self.norm_r`,level=3)
             if self.updateJacobian or self.fullNewton and not self.isFactored:
                 self.updateJacobian = False
                 self.F.getJacobian(self.J)
@@ -1541,7 +1539,7 @@ class SSPRKNewton(Newton):
                                                                         self.atol_r,
                                                                         self.rtol_r)
                 if ls_its > 0:
-                    log("Linesearches = %i" % ls_its,level=3)
+                    logEvent("Linesearches = %i" % ls_its,level=3)
         else:
             if self.linearSolver.computeEigenvalues:
                 if self.betaK_0*self.etaK_0*self.gammaK_max <= 0.5:
@@ -1659,7 +1657,7 @@ class PicardNewton(Newton):
         while (not self.converged(r) and
                not self.failed()):
             if self.maxIts>1:
-                log("   Newton it %d norm(r) = %12.5e  %12.5g \t\t norm(r)/(rtol*norm(r0)+atol) = %g"
+                logEvent("   Newton it %d norm(r) = %12.5e  %12.5g \t\t norm(r)/(rtol*norm(r0)+atol) = %g"
                             % (self.its-1,self.norm_r,100*(self.norm_r/self.norm_r0),(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
             if self.updateJacobian or self.fullNewton:
                 self.updateJacobian = False
@@ -1763,12 +1761,12 @@ class PicardNewton(Newton):
                         else:
                             par_r.scatter_forward_insert()
                     norm_r_cur = self.norm(r)
-                    log("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
+                    logEvent("""ls #%d norm_r_cur=%s atol=%g rtol=%g""" % (ls_its,
                                                                            norm_r_cur,
                                                                            self.atol_r,
                                                                            self.rtol_r))
                 if ls_its > 0:
-                    log("Linesearches = %i" % ls_its,level=3)
+                    logEvent("Linesearches = %i" % ls_its,level=3)
         else:
             if self.linearSolver.computeEigenvalues:
                 if self.betaK_0*self.etaK_0*self.gammaK_max <= 0.5:
@@ -1813,7 +1811,7 @@ class PicardNewton(Newton):
                     Viewers.newPlot()
                     Viewers.newWindow()
             if self.maxIts>1:
-                log("   Newton it %d norm(r) = %12.5e  %12.5g \t\t norm(r)/(rtol*norm(r0)+atol) = %g"
+                logEvent("   Newton it %d norm(r) = %12.5e  %12.5g \t\t norm(r)/(rtol*norm(r0)+atol) = %g"
                              % (self.its-1,self.norm_r,100*(self.norm_r/self.norm_r0),(self.norm_r/(self.rtol_r*self.norm_r0+self.atol_r))),level=1)
             return self.failedFlag
 
@@ -2326,7 +2324,7 @@ class EikonalSolver:
 
         if (self.localReconstruction == 'localPWL' and
             self.eikonalVariableFemSpace != FemTools.C0_AffineLinearOnSimplexWithNodalBasis):
-            log("""WARNING EikonalSolver localReconstruction = %s only allowed with P1C0 for now""" % self.localReconstruction)
+            logEvent("""WARNING EikonalSolver localReconstruction = %s only allowed with P1C0 for now""" % self.localReconstruction)
             self.localReconstruction = None
         #if
         #do not overwrite values from input if magnitude <  bandTolerance
@@ -3043,7 +3041,7 @@ def multilevelNonlinearSolverChooser(nonlinearOperatorList,
                                                               printInfo = printSolverInfo)
     elif multilevelNonlinearSolverType == MultilevelEikonalSolver:
         #should I take care of assignment here
-        log("Warning Using Multilevel Eikonal Equation Solver, hope equation is correct!")
+        logEvent("Warning Using Multilevel Eikonal Equation Solver, hope equation is correct!")
         multilevelNonlinearSolver = MultilevelEikonalSolver(levelNonlinearSolverList,
                                                             printInfo = printSolverInfo)
 

--- a/proteus/NumericalFlux.py
+++ b/proteus/NumericalFlux.py
@@ -6,7 +6,7 @@ A class hierarchy for numerical flux (numerical trace) computations
 """
 import cfemIntegrals,cnumericalFlux
 import numpy
-from Profiling import logEvent,memory
+from .Profiling import logEvent,memory
 from EGeometry import enorm
 #TODO:
 #  allow different flags for Dirichlet bc's, keep isDOFBoundary = 1 by default

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -21,7 +21,7 @@ import Viewers
 from Archiver import ArchiveFlags
 import Domain
 
-log = Profiling.logEvent
+from .Profiling import logEvent
 
 # Global to control whether the kernel starting is active.
 embed_ok = True
@@ -66,7 +66,7 @@ class NS_base:  # (HasTraits):
         message = "Initializing NumericalSolution for "+so.name+"\n System includes: \n"
         for p in pList:
             message += p.name+"\n"
-        log(message)
+        logEvent(message)
         self.so=so
         self.pList=pList
         self.nList=nList
@@ -78,7 +78,7 @@ class NS_base:  # (HasTraits):
         if not so.useOneMesh:
             so.useOneArchive=False
 
-        log("Setting Archiver(s)")
+        logEvent("Setting Archiver(s)")
 
         if so.useOneArchive:
             self.femSpaceWritten={}
@@ -114,28 +114,28 @@ class NS_base:  # (HasTraits):
                         elif recType[0] == 'pod_residuals':
                             self.archive_pod_residuals[index]=True
                         else:
-                            log("Warning Numerical Solution storeQuantity = %s not recognized won't archive" % quant)
+                            logEvent("Warning Numerical Solution storeQuantity = %s not recognized won't archive" % quant)
                     #
                 #
             #
         #
-        log("Setting up MultilevelMesh")
+        logEvent("Setting up MultilevelMesh")
         mlMesh_nList = []
         if so.useOneMesh:
-            log("Building one multilevel mesh for all models")
+            logEvent("Building one multilevel mesh for all models")
             nListForMeshGeneration=[nList[0]]
             pListForMeshGeneration=[pList[0]]
         else:
-            log("Building seperate meshes for each model")
+            logEvent("Building seperate meshes for each model")
             nListForMeshGeneration=nList
             pListForMeshGeneration=pList
 
         for p,n in zip(pListForMeshGeneration,nListForMeshGeneration):
             if opts.hotStart:
                 p.genMesh = False
-                log("Hotstarting, using existing mesh "+p.name)
+                logEvent("Hotstarting, using existing mesh "+p.name)
             else:
-                log("Generating mesh for "+p.name)
+                logEvent("Generating mesh for "+p.name)
             #support for old-style domain input
             if p.domain == None:
                 if p.nd == 1:
@@ -175,7 +175,7 @@ class NS_base:  # (HasTraits):
                     else:
                         nnx = n.nnx
                         nny = n.nny
-                    log("Building %i x %i rectangular mesh for %s" % (nnx,nny,p.name))
+                    logEvent("Building %i x %i rectangular mesh for %s" % (nnx,nny,p.name))
 
                     if not hasattr(n,'quad'):
                         n.quad = False
@@ -202,7 +202,7 @@ class NS_base:  # (HasTraits):
                         nnx = n.nnx
                         nny = n.nny
                         nnz = n.nnz
-                    log("Building %i x %i x %i rectangular mesh for %s" % (nnx,nny,nnz,p.name))
+                    logEvent("Building %i x %i x %i rectangular mesh for %s" % (nnx,nny,nnz,p.name))
 
                     if not hasattr(n,'hex'):
                         n.hex = False
@@ -239,14 +239,14 @@ class NS_base:  # (HasTraits):
                                                                      parallelPartitioningType=n.parallelPartitioningType)
 
             elif isinstance(p.domain,Domain.PlanarStraightLineGraphDomain):
-                log("Calling Triangle to generate 2D mesh for"+p.name)
+                logEvent("Calling Triangle to generate 2D mesh for"+p.name)
                 tmesh = TriangleTools.TriangleBaseMesh(baseFlags=n.triangleOptions,
                                                        nbase=1,
                                                        verbose=10)
                 if comm.isMaster() and p.genMesh:
                     tmesh.readFromPolyFile(p.domain.polyfile)
                     tmesh.writeToFile(p.domain.polyfile)
-                    log("Converting to Proteus Mesh")
+                    logEvent("Converting to Proteus Mesh")
                     mesh=tmesh.convertToProteusMesh(verbose=1)
                 comm.barrier()
                 if not comm.isMaster() or not p.genMesh:
@@ -255,7 +255,7 @@ class NS_base:  # (HasTraits):
                 mlMesh = MeshTools.MultilevelTriangularMesh(0,0,0,skipInit=True,
                                                             nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                             parallelPartitioningType=n.parallelPartitioningType)
-                log("Generating %i-level mesh from coarse Triangle mesh" % (n.nLevels,))
+                logEvent("Generating %i-level mesh from coarse Triangle mesh" % (n.nLevels,))
                 mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                       nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                       parallelPartitioningType=n.parallelPartitioningType)
@@ -265,13 +265,13 @@ class NS_base:  # (HasTraits):
                 if comm.rank() == 0 and (p.genMesh or not (os.path.exists(p.domain.polyfile+".ele") and
                                                            os.path.exists(p.domain.polyfile+".node") and
                                                            os.path.exists(p.domain.polyfile+".face"))):
-                    log("Running tetgen to generate 3D mesh for "+p.name,level=1)
+                    logEvent("Running tetgen to generate 3D mesh for "+p.name,level=1)
                     tetcmd = "tetgen -%s %s.poly" % (n.triangleOptions,p.domain.polyfile)
-                    log("Calling tetgen on rank 0 with command %s" % (tetcmd,))
+                    logEvent("Calling tetgen on rank 0 with command %s" % (tetcmd,))
 
                     check_call(tetcmd, shell=True)
 
-                    log("Done running tetgen")
+                    logEvent("Done running tetgen")
                     elefile  = "%s.1.ele" % p.domain.polyfile
                     nodefile = "%s.1.node" % p.domain.polyfile
                     facefile = "%s.1.face" % p.domain.polyfile
@@ -293,73 +293,73 @@ class NS_base:  # (HasTraits):
                         os.rename(edgefile,tmp)
                         assert os.path.exists(tmp), "no .edge"
                 comm.barrier()
-                log("Initializing mesh and MultilevelMesh")
+                logEvent("Initializing mesh and MultilevelMesh")
                 nbase = 1
                 mesh=MeshTools.TetrahedralMesh()
                 mlMesh = MeshTools.MultilevelTetrahedralMesh(0,0,0,skipInit=True,
                                                              nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                              parallelPartitioningType=n.parallelPartitioningType)
                 if opts.generatePartitionedMeshFromFiles:
-                    log("Generating partitioned mesh from Tetgen files")
+                    logEvent("Generating partitioned mesh from Tetgen files")
                     mlMesh.generatePartitionedMeshFromTetgenFiles(p.domain.polyfile,nbase,mesh,n.nLevels,
                                                                   nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                                   parallelPartitioningType=n.parallelPartitioningType)
                 else:
-                    log("Generating coarse global mesh from Tetgen files")
+                    logEvent("Generating coarse global mesh from Tetgen files")
                     mesh.generateFromTetgenFiles(p.domain.polyfile,nbase,parallel = comm.size() > 1)
-                    log("Generating partitioned %i-level mesh from coarse global Tetgen mesh" % (n.nLevels,))
+                    logEvent("Generating partitioned %i-level mesh from coarse global Tetgen mesh" % (n.nLevels,))
                     mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                           nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                           parallelPartitioningType=n.parallelPartitioningType)
             elif isinstance(p.domain,Domain.MeshTetgenDomain):
                 mesh=MeshTools.TetrahedralMesh()
-                log("Reading coarse mesh from tetgen file")
+                logEvent("Reading coarse mesh from tetgen file")
                 mesh.generateFromTetgenFiles(p.domain.meshfile,1)
                 mlMesh = MeshTools.MultilevelTetrahedralMesh(0,0,0,skipInit=True,
                                                              nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                              parallelPartitioningType=n.parallelPartitioningType)
-                log("Generating %i-level mesh from coarse Tetgen mesh" % (n.nLevels,))
+                logEvent("Generating %i-level mesh from coarse Tetgen mesh" % (n.nLevels,))
                 mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                       nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                       parallelPartitioningType=n.parallelPartitioningType)
             elif isinstance(p.domain,Domain.Mesh3DMDomain):
                 mesh=MeshTools.TetrahedralMesh()
-                log("Reading coarse mesh from 3DM file")
+                logEvent("Reading coarse mesh from 3DM file")
                 mesh.generateFrom3DMFile(p.domain.meshfile)
                 mlMesh = MeshTools.MultilevelTetrahedralMesh(0,0,0,skipInit=True,
                                                              nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                              parallelPartitioningType=n.parallelPartitioningType)
-                log("Generating %i-level mesh from coarse 3DM mesh" % (n.nLevels,))
+                logEvent("Generating %i-level mesh from coarse 3DM mesh" % (n.nLevels,))
                 mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                       nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                       parallelPartitioningType=n.parallelPartitioningType)
             elif isinstance(p.domain,Domain.MeshHexDomain):
                 mesh=MeshTools.HexahedralMesh()
-                log("Reading coarse mesh from file")
+                logEvent("Reading coarse mesh from file")
                 mesh.generateFromHexFile(p.domain.meshfile)
                 mlMesh = MeshTools.MultilevelHexahedralMesh(0,0,0,skipInit=True,
                                                              nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                              parallelPartitioningType=n.parallelPartitioningType)
-                log("Generating %i-level mesh from coarse mesh" % (n.nLevels,))
+                logEvent("Generating %i-level mesh from coarse mesh" % (n.nLevels,))
                 mlMesh.generateFromExistingCoarseMesh(mesh,n.nLevels,
                                                       nLayersOfOverlap=n.nLayersOfOverlapForParallel,
                                                       parallelPartitioningType=n.parallelPartitioningType)
             mlMesh_nList.append(mlMesh)
             if opts.viewMesh:
-                log("Attempting to visualize mesh")
+                logEvent("Attempting to visualize mesh")
                 try:
                     from proteusGraphical import vtkViewers
                     vtkViewers.ViewMesh(mlMesh.meshList[0],viewMaterialTypes=True)
                     vtkViewers.ViewBoundaryMesh(mlMesh.meshList[0],viewBoundaryMaterialTypes=True)
                 except:
-                    log("NumericalSolution ViewMesh failed for coarse mesh")
+                    logEvent("NumericalSolution ViewMesh failed for coarse mesh")
             for l in range(n.nLevels):
                 try:
-                    log(mlMesh.meshList[l].meshInfo())
+                    logEvent(mlMesh.meshList[l].meshInfo())
                 except:
-                    log("meshInfo() method not implemented for this mesh type")
+                    logEvent("meshInfo() method not implemented for this mesh type")
                 if opts.viewMesh and opts.viewLevels and l > 0:
-                    log("Attempting to visualize mesh")
+                    logEvent("Attempting to visualize mesh")
                     try:
                         from proteusGraphical import vtkViewers
                         vtkViewers.ViewMesh(mlMesh.meshList[l],title="mesh level %s " % l,
@@ -367,7 +367,7 @@ class NS_base:  # (HasTraits):
                         vtkViewers.ViewBoundaryMesh(mlMesh.meshList[l],title="boundary mesh level %s " % l,
                                                     viewBoundaryMaterialTypes=True)
                     except:
-                        log("NumericalSolution ViewMesh failed for mesh level %s" % l)
+                        logEvent("NumericalSolution ViewMesh failed for mesh level %s" % l)
         if so.useOneMesh:
             for p in pList[1:]: mlMesh_nList.append(mlMesh)
         Profiling.memory("Mesh")
@@ -385,7 +385,7 @@ class NS_base:  # (HasTraits):
                         if not p.coefficients.sdInfo.has_key((ci,ck)):
                             p.coefficients.sdInfo[(ci,ck)] = (numpy.arange(start=0,stop=p.nd**2+1,step=p.nd,dtype='i'),
                                                               numpy.array([range(p.nd) for row in range(p.nd)],dtype='i').flatten())
-                            log("Numerical Solution Sparse diffusion information key "+`(ci,ck)`+' = '+`p.coefficients.sdInfo[(ci,ck)]`)
+                            logEvent("Numerical Solution Sparse diffusion information key "+`(ci,ck)`+' = '+`p.coefficients.sdInfo[(ci,ck)]`)
 
         for p,n,s,mlMesh,index in zip(pList,nList,sList,mlMesh_nList,range(len(pList))):
             if so.needEBQ_GLOBAL:
@@ -405,14 +405,14 @@ class NS_base:  # (HasTraits):
                 tolList.append(n.tolFac*fac)
                 linTolList.append(n.linTolFac*fac)
 
-            log("Setting up MultilevelTransport for "+p.name)
+            logEvent("Setting up MultilevelTransport for "+p.name)
             model = Transport.MultilevelTransport(p,n,mlMesh,OneLevelTransportType=p.LevelModelType)
             self.modelList.append(model)
             model.name = p.name
-            log("Setting "+model.name+" stepController to "+str(n.stepController))
+            logEvent("Setting "+model.name+" stepController to "+str(n.stepController))
             model.stepController = n.stepController(model,n)
             Profiling.memory("MultilevelTransport for"+p.name)
-            log("Setting up MultilevelLinearSolver for"+p.name)
+            logEvent("Setting up MultilevelLinearSolver for"+p.name)
             #allow options database to set model specific parameters?
             linear_solver_options_prefix = None
             if 'linear_solver_options_prefix' in dir(n):
@@ -447,7 +447,7 @@ class NS_base:  # (HasTraits):
                 computeEigenvalues = n.computeEigenvalues)
             self.lsList.append(multilevelLinearSolver)
             Profiling.memory("MultilevelLinearSolver for "+p.name)
-            log("Setting up MultilevelNonLinearSolver for "+p.name)
+            logEvent("Setting up MultilevelNonLinearSolver for "+p.name)
             self.nlsList.append(NonlinearSolvers.multilevelNonlinearSolverChooser(
                 model.levelModelList,
                 model.jacobianList,
@@ -494,14 +494,14 @@ class NS_base:  # (HasTraits):
             #collect models to be used for spin up
         for index in so.modelSpinUpList:
             self.modelSpinUp[index] = self.modelList[index]
-        log("Finished setting up models and solvers")
+        logEvent("Finished setting up models and solvers")
         if self.opts.save_dof:
             for m in self.modelList:
                 for lm in m.levelModelList:
                     for ci in range(lm.coefficients.nc):
                         lm.u[ci].dof_last = lm.u[ci].dof.copy()
         self.archiveFlag= so.archiveFlag
-        log("Setting up SimTools for "+p.name)
+        logEvent("Setting up SimTools for "+p.name)
         self.simOutputList = []
         self.auxiliaryVariables = {}
         if self.simFlagsList != None:
@@ -520,35 +520,35 @@ class NS_base:  # (HasTraits):
         for avList in self.auxiliaryVariables.values():
             for av in avList:
                 av.attachAuxiliaryVariables(self.auxiliaryVariables)
-        log(Profiling.memory("NumericalSolution memory",className='NumericalSolution',memSaved=memBase))
+        logEvent(Profiling.memory("NumericalSolution memory",className='NumericalSolution',memSaved=memBase))
         if so.tnList == None:
-            log("Building tnList from model = "+pList[0].name+" nDTout = "+`nList[0].nDTout`)
+            logEvent("Building tnList from model = "+pList[0].name+" nDTout = "+`nList[0].nDTout`)
             self.tnList=[float(n)*nList[0].T/float(nList[0].nDTout)
                          for n in range(nList[0].nDTout+1)]
         else:
-            log("Using tnList from so = "+so.name)
+            logEvent("Using tnList from so = "+so.name)
             self.tnList = so.tnList
-        log("Time sequence"+`self.tnList`)
-        log("Setting "+so.name+" systemStepController to object of type "+str(so.systemStepControllerType))
+        logEvent("Time sequence"+`self.tnList`)
+        logEvent("Setting "+so.name+" systemStepController to object of type "+str(so.systemStepControllerType))
         self.systemStepController = so.systemStepControllerType(self.modelList,stepExact=so.systemStepExact)
         self.systemStepController.setFromOptions(so)
-        log("Finished NumericalSolution initialization")
+        logEvent("Finished NumericalSolution initialization")
 
     ## compute the solution
     def calculateSolution(self,runName):
-        log("Setting initial conditions",level=0)
+        logEvent("Setting initial conditions",level=0)
         for index,p,n,m,simOutput in zip(range(len(self.modelList)),self.pList,self.nList,self.modelList,self.simOutputList):
             if self.opts.hotStart:
-                log("Setting initial conditions from hot start file for "+p.name)
+                logEvent("Setting initial conditions from hot start file for "+p.name)
                 tCount = int(self.ar[index].tree.getroot()[-1][-1][-1][0].attrib['Name'])
                 self.ar[index].n_datasets = tCount+1
                 time = float(self.ar[index].tree.getroot()[-1][-1][-1][0].attrib['Value'])
                 if len(self.ar[index].tree.getroot()[-1][-1]) > 1:
                     dt = time - float(self.ar[index].tree.getroot()[-1][-1][-2][0].attrib['Value'])
                 else:
-                    log("Only one step in hot start file, setting dt to 1.0")
+                    logEvent("Only one step in hot start file, setting dt to 1.0")
                     dt = 1.0
-                log("Last time step in hot start file was t = "+`time`)
+                logEvent("Last time step in hot start file was t = "+`time`)
                 for lm,lu,lr in zip(m.levelModelList,m.uList,m.rList):
                     for cj in range(lm.coefficients.nc):
                         lm.u[cj].femSpace.readFunctionXdmf(self.ar[index],lm.u[cj],tCount)
@@ -558,31 +558,31 @@ class NS_base:  # (HasTraits):
                         lm.timeIntegration.dt = dt
                 self.tCount = tCount+1
             elif p.initialConditions != None:
-                log("Setting initial conditions for "+p.name)
+                logEvent("Setting initial conditions for "+p.name)
                 m.setInitialConditions(p.initialConditions,self.tnList[0])
                 #It's only safe to calculate the solution and solution
                 #gradients because the models aren't attached yet
                 for lm in m.levelModelList:
                     lm.calculateSolutionAtQuadrature()
             else:
-                log("No initial conditions provided for model "+p.name)
+                logEvent("No initial conditions provided for model "+p.name)
         if self.opts.hotStart:
             if time >= self.tnList[-1] - 1.0e-5:
-                log("Modifying time interval to be tnList[-1] + tnList since tnList hasn't been modified already")
+                logEvent("Modifying time interval to be tnList[-1] + tnList since tnList hasn't been modified already")
                 ndtout = len(self.tnList)
                 dtout = (self.tnList[-1] - self.tnList[0])/float(ndtout-1)
                 self.tnList = [time + i*dtout for i in range(ndtout)]
-                log("New tnList"+`self.tnList`)
+                logEvent("New tnList"+`self.tnList`)
             else:
                 tnListNew=[time]
                 for n,t in enumerate(self.tnList):
                     if time < t-1.0e-8:
                         tnListNew.append(t)
                 self.tnList=tnListNew
-                log("Hotstarting, new tnList is"+`self.tnList`)
+                logEvent("Hotstarting, new tnList is"+`self.tnList`)
         else:
             self.tCount=0#time step counter
-        log("Attaching models and running spin-up step if requested")
+        logEvent("Attaching models and running spin-up step if requested")
         self.firstStep = True ##\todo get rid of firstStep flag in NumericalSolution if possible?
         spinup = []
         for index,m in self.modelSpinUp.iteritems():
@@ -591,10 +591,10 @@ class NS_base:  # (HasTraits):
             if index not in self.modelSpinUp:
                 spinup.append((self.pList[index],self.nList[index],m,self.simOutputList[index]))
         for p,n,m,simOutput in spinup:
-            log("Attaching models to model "+p.name)
+            logEvent("Attaching models to model "+p.name)
             m.attachModels(self.modelList)
             if m in self.modelSpinUp.values():
-                log("Spin-Up Estimating initial time derivative and initializing time history for model "+p.name)
+                logEvent("Spin-Up Estimating initial time derivative and initializing time history for model "+p.name)
                 #now the models are attached so we can calculate the coefficients
                 for lm,lu,lr in zip(m.levelModelList,
                                     m.uList,
@@ -614,14 +614,14 @@ class NS_base:  # (HasTraits):
                     lm.estimate_mt()
                     #post-process velocity
                     lm.calculateAuxiliaryQuantitiesAfterStep()
-                log("Spin-Up Choosing initial time step for model "+p.name)
+                logEvent("Spin-Up Choosing initial time step for model "+p.name)
                 m.stepController.initialize_dt_model(self.tnList[0],self.tnList[1])
                 #mwf what if user wants spin-up to be over (t_0,t_1)?
 
                 if m.stepController.stepExact and m.stepController.t_model_last != self.tnList[1]:
-                    log("Spin-up step exact called for model %s" % (m.name,),level=3)
+                    logEvent("Spin-up step exact called for model %s" % (m.name,),level=3)
                     m.stepController.stepExact_model(self.tnList[1])
-                log("Spin-Up Initializing time history for model step controller")
+                logEvent("Spin-Up Initializing time history for model step controller")
                 m.stepController.initializeTimeHistory()
                 m.stepController.setInitialGuess(m.uList,m.rList)
                 solverFailed = m.solver.solveMultilevel(uList=m.uList,
@@ -630,27 +630,27 @@ class NS_base:  # (HasTraits):
                                                         par_rList=m.par_rList)
                 Profiling.memory("solver.solveMultilevel")
                 if solverFailed:
-                    log("Spin-Up Step Failed t=%12.5e, dt=%12.5e for model %s, CONTINUING ANYWAY!" %  (m.stepController.t_model,
+                    logEvent("Spin-Up Step Failed t=%12.5e, dt=%12.5e for model %s, CONTINUING ANYWAY!" %  (m.stepController.t_model,
                                                                                                      m.stepController.dt_model,
                                                                                                      m.name))
 
                 else:
                     if n.restrictFineSolutionToAllMeshes:
-                        log("Using interpolant of fine mesh an all meshes")
+                        logEvent("Using interpolant of fine mesh an all meshes")
                         self.restrictFromFineMesh(m)
                     self.postStep(m)
                     self.systemStepController.modelStepTaken(m,self.tnList[0])
-                    log("Spin-Up Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (m.stepController.t_model,
+                    logEvent("Spin-Up Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (m.stepController.t_model,
                                                                                              m.stepController.dt_model,
                                                                                              m.name))
         for p,n,m,simOutput,index in zip(self.pList,self.nList,self.modelList,self.simOutputList,range(len(self.pList))):
             if not self.opts.hotStart:
-                log("Archiving initial conditions")
+                logEvent("Archiving initial conditions")
                 self.archiveInitialSolution(m,index)
             else:
                 self.ar[index].domain = self.ar[index].tree.find("Domain")
             self.initializeViewSolution(m)
-            log("Estimating initial time derivative and initializing time history for model "+p.name)
+            logEvent("Estimating initial time derivative and initializing time history for model "+p.name)
             #now the models are attached so we can calculate the coefficients
             for lm,lu,lr in zip(m.levelModelList,
                                 m.uList,
@@ -674,21 +674,21 @@ class NS_base:  # (HasTraits):
                 #calculate consistent
                 lm.estimate_mt()
                 #
-            log("Choosing initial time step for model "+p.name)
+            logEvent("Choosing initial time step for model "+p.name)
             m.stepController.initialize_dt_model(self.tnList[0],self.tnList[1])
             #recalculate  with all terms ready
             for lm,lu,lr in zip(m.levelModelList,
                                 m.uList,
                                 m.rList):
                 lm.getResidual(lu,lr)
-            log("Initializing time history for model step controller")
+            logEvent("Initializing time history for model step controller")
             m.stepController.initializeTimeHistory()
         self.systemStepController.initialize_dt_system(self.tnList[0],self.tnList[1]) #may reset other dt's
         for m in self.modelList:
-            log("Auxiliary variable calculations for model %s" % (m.name,))
+            logEvent("Auxiliary variable calculations for model %s" % (m.name,))
             for av in self.auxiliaryVariables[m.name]:
                 av.calculate_init()
-        log("Starting time stepping",level=0)
+        logEvent("Starting time stepping",level=0)
         systemStepFailed=False
         stepFailed=False
 
@@ -705,9 +705,9 @@ class NS_base:  # (HasTraits):
         #a loop for substeps(stages).
 
         for (self.tn_last,self.tn) in zip(self.tnList[:-1],self.tnList[1:]):
-            log("==============================================================",level=0)
-            log("Solving over interval [%12.5e,%12.5e]" % (self.tn_last,self.tn),level=0)
-            log("==============================================================",level=0)
+            logEvent("==============================================================",level=0)
+            logEvent("Solving over interval [%12.5e,%12.5e]" % (self.tn_last,self.tn),level=0)
+            logEvent("==============================================================",level=0)
             if self.opts.save_dof:
                 for m in self.modelList:
                     for lm in m.levelModelList:
@@ -717,17 +717,17 @@ class NS_base:  # (HasTraits):
                 self.systemStepController.stepExact_system(self.tn)
             while self.systemStepController.t_system_last < self.tn:
 
-                log("System time step t=%12.5e, dt=%12.5e" % (self.systemStepController.t_system,
+                logEvent("System time step t=%12.5e, dt=%12.5e" % (self.systemStepController.t_system,
                                                               self.systemStepController.dt_system),level=3)
 
                 while (not self.systemStepController.converged() and
                        not systemStepFailed):
-                    log("Split operator iteration %i" % (self.systemStepController.its,),level=3)
+                    logEvent("Split operator iteration %i" % (self.systemStepController.its,),level=3)
 
                     for (self.t_stepSequence,model) in self.systemStepController.stepSequence:
 
-                        log("Model: %s" % (model.name),level=1)
-                        log("Fractional step %12.5e for model %s" % (self.t_stepSequence,model.name),level=3)
+                        logEvent("Model: %s" % (model.name),level=1)
+                        logEvent("Fractional step %12.5e for model %s" % (self.t_stepSequence,model.name),level=3)
 
                         for m in model.levelModelList:
                             if m.movingDomain and m.tLast_mesh != self.systemStepController.t_system_last:
@@ -739,21 +739,21 @@ class NS_base:  # (HasTraits):
 
                         stepFailed = False
                         if model.stepController.stepExact and model.stepController.t_model_last != self.t_stepSequence:
-                            log("Step exact called for model %s" % (model.name,),level=3)
+                            logEvent("Step exact called for model %s" % (model.name,),level=3)
                             model.stepController.stepExact_model(self.t_stepSequence)
                         while (model.stepController.t_model_last < self.t_stepSequence and
                                not stepFailed and
                                not self.systemStepController.exitModelStep[model]):
 
-                            log("Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
+                            logEvent("Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
                                                                                  model.stepController.dt_model,
                                                                                  model.name),level=3)
 
                             for self.tSubstep in model.stepController.substeps:
 
-                                log("Model substep t=%12.5e for model %s" % (self.tSubstep,model.name),level=3)
+                                logEvent("Model substep t=%12.5e for model %s" % (self.tSubstep,model.name),level=3)
                                 #TODO: model.stepController.substeps doesn't seem to be updated after a solver failure unless model.stepController.stepExact is true
-                                log("Model substep t=%12.5e for model %s model.timeIntegration.t= %12.5e" % (self.tSubstep,model.name,model.levelModelList[-1].timeIntegration.t),level=3)
+                                logEvent("Model substep t=%12.5e for model %s model.timeIntegration.t= %12.5e" % (self.tSubstep,model.name,model.levelModelList[-1].timeIntegration.t),level=3)
 
                                 model.stepController.setInitialGuess(model.uList,model.rList)
 
@@ -768,30 +768,30 @@ class NS_base:  # (HasTraits):
                                     break
                                 else:
                                     if n.restrictFineSolutionToAllMeshes:
-                                        log("Using interpolant of fine mesh an all meshes")
+                                        logEvent("Using interpolant of fine mesh an all meshes")
                                         self.restrictFromFineMesh(model)
                                     model.stepController.updateSubstep()
                             #end model substeps
                             if solverFailed:
-                                log("Step failed due to solver failure")
+                                logEvent("Step failed due to solver failure")
                                 stepFailed = not self.systemStepController.retryModelStep_solverFailure(model)
                             elif model.stepController.errorFailure():
-                                log("Step failed due to error failure")
+                                logEvent("Step failed due to error failure")
                                 stepFailed = not self.systemStepController.retryModelStep_errorFailure(model)
                             else:
                                 #set up next step
                                 self.systemStepController.modelStepTaken(model,self.t_stepSequence)
-                                log("Step Taken, t_stepSequence= %s Model step t=%12.5e, dt=%12.5e for model %s" % (self.t_stepSequence,
+                                logEvent("Step Taken, t_stepSequence= %s Model step t=%12.5e, dt=%12.5e for model %s" % (self.t_stepSequence,
                                                                                                                     model.stepController.t_model,
                                                                                                                     model.stepController.dt_model,
                                                                                                                     model.name),level=3)
                         #end model step
                         if stepFailed:
-                            log("Sequence step failed")
+                            logEvent("Sequence step failed")
                             if not self.systemStepController.ignoreSequenceStepFailure(model):
                                 break
                             else:
-                                log("IGNORING STEP FAILURE")
+                                logEvent("IGNORING STEP FAILURE")
                                 self.postStep(model)
                                 self.systemStepController.sequenceStepTaken(model)
                         else:
@@ -802,9 +802,9 @@ class NS_base:  # (HasTraits):
                         systemStepFailed = not self.systemStepController.retrySequence_modelStepFailure()
                         if not systemStepFailed:
                             stepFailed=False
-                            log("Retrying sequence")
+                            logEvent("Retrying sequence")
                         else:
-                            log("Sequence failed")
+                            logEvent("Sequence failed")
                     else:
                         self.firstStep=False
                         systemStepFailed=False
@@ -817,25 +817,25 @@ class NS_base:  # (HasTraits):
                                 self.archiveSolution(model,index,self.systemStepController.t_system)
                 #end system split operator sequence
                 if systemStepFailed:
-                    log("System Step Failed")
+                    logEvent("System Step Failed")
                     #go ahead and update as if the time step had succeeded
                     self.postStep(model)
                     self.systemStepController.modelStepTaken(model,self.t_stepSequence)
                     self.systemStepController.sequenceTaken()
                     self.systemStepController.updateTimeHistory()
                     #you're dead if retrySequence didn't work
-                    log("Step Failed, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
+                    logEvent("Step Failed, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
                                                                                       model.stepController.dt_model,
                                                                                       model.name))
                     break
                 else:
                     self.systemStepController.updateTimeHistory()
                     self.systemStepController.choose_dt_system()
-                    log("Step Taken, System time step t=%12.5e, dt=%12.5e" % (self.systemStepController.t_system,
+                    logEvent("Step Taken, System time step t=%12.5e, dt=%12.5e" % (self.systemStepController.t_system,
                                                                               self.systemStepController.dt_system))
                     if self.systemStepController.stepExact and self.systemStepController.t_system_last != self.tn:
                         self.systemStepController.stepExact_system(self.tn)
-                    log("Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
+                    logEvent("Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
                                                                                      model.stepController.dt_model,
                                                                                      model.name))
                 for model in self.modelList:
@@ -852,7 +852,7 @@ class NS_base:  # (HasTraits):
                     self.archiveSolution(model,index,self.systemStepController.t_system_last)
             if systemStepFailed:
                 break
-        log("Finished calculating solution",level=3)
+        logEvent("Finished calculating solution",level=3)
         for index,model in enumerate(self.modelList):
             self.finalizeViewSolution(model)
             self.closeArchive(model,index)
@@ -907,8 +907,8 @@ class NS_base:  # (HasTraits):
         import xml.etree.ElementTree as ElementTree
         if self.archiveFlag == ArchiveFlags.UNDEFINED:
             return
-        log("Writing initial mesh for  model = "+model.name,level=3)
-        log("Writing initial conditions for  model = "+model.name,level=3)
+        logEvent("Writing initial mesh for  model = "+model.name,level=3)
+        logEvent("Writing initial conditions for  model = "+model.name,level=3)
         if not self.so.useOneArchive or index==0:
             self.ar[index].domain = ElementTree.SubElement(self.ar[index].tree.getroot(),"Domain")
         if self.so.useOneArchive:
@@ -970,8 +970,8 @@ class NS_base:  # (HasTraits):
         if t == None:
             t = self.systemStepController.t_system
 
-        log("Writing mesh header for  model = "+model.name+" at time t="+str(t),level=3)
-        log("Writing solution for  model = "+model.name,level=3)
+        logEvent("Writing mesh header for  model = "+model.name+" at time t="+str(t),level=3)
+        logEvent("Writing solution for  model = "+model.name,level=3)
         if self.so.useOneArchive:
             if index==0:
                 self.femSpaceWritten={}
@@ -1037,10 +1037,10 @@ class NS_base:  # (HasTraits):
             return
         if self.so.useOneArchive:
             if index==0:
-                log("Closing solution archive for "+self.so.name)
+                logEvent("Closing solution archive for "+self.so.name)
                 self.ar[index].close()
         else:
-            log("Closing solution archive for "+model.name)
+            logEvent("Closing solution archive for "+model.name)
             self.ar[index].close()
 
     def initializeViewSolution(self,model):

--- a/proteus/PostProcessingTools.py
+++ b/proteus/PostProcessingTools.py
@@ -12,7 +12,7 @@ import LinearSolvers
 from LinearAlgebraTools import Mat,Vec,SparseMatFromDict
 import cfemIntegrals
 import cpostprocessing
-from Profiling import logEvent
+from .Profiling import logEvent
 import Norms
 import Archiver
 

--- a/proteus/Quadrature.py
+++ b/proteus/Quadrature.py
@@ -5,7 +5,7 @@ A class hierarchy for numerical integration on reference domains in 1,2, and 3D.
    :parts: 1
 """
 from EGeometry import *
-from Profiling import logEvent
+from .Profiling import logEvent
 from math import *
 
 class Q_base:

--- a/proteus/SimTools.py
+++ b/proteus/SimTools.py
@@ -7,7 +7,7 @@ Collect higher level tools for running simulation, processing results, etc
 import Norms
 import numpy
 import FemTools
-from Profiling import logEvent
+from .Profiling import logEvent
 
 from proteus import Comm
 comm = Comm.get()

--- a/proteus/SpatialTools.py
+++ b/proteus/SpatialTools.py
@@ -32,7 +32,7 @@ from math import cos, sin, sqrt
 import sys
 import numpy as np
 from proteus import BoundaryConditions as bc
-from proteus.Profiling import logEvent as log
+from .Profiling import logEvent
 
 
 class Shape(object):
@@ -44,7 +44,7 @@ class Shape(object):
 
     def __init__(self, domain, nd=None, BC_class=None):
         if nd != domain.nd:
-            log('Shape ('+`nd`+'D) and Domain ('+`domain.nd`+'D)' \
+            logEvent('Shape ('+`nd`+'D) and Domain ('+`domain.nd`+'D)' \
                 ' have different dimensions!')
             sys.exit()
         self.Domain = domain
@@ -741,6 +741,6 @@ def _generateMesh(domain):
     if mesh.outputFiles['asymptote'] is True:
         domain.writeAsymptote(mesh.outputFiles['name'])
     mesh.setTriangleOptions()
-    log("""Mesh generated using: tetgen -%s %s"""  %
+    logEvent("""Mesh generated using: tetgen -%s %s"""  %
         (mesh.triangleOptions, domain.polyfile+".poly"))
 

--- a/proteus/SplitOperator.py
+++ b/proteus/SplitOperator.py
@@ -4,8 +4,7 @@ A class hierarchy for split operator methods.
 .. inheritance-diagram:: proteus.SplitOperator
    :parts: 1
 """
-import Profiling
-log = Profiling.logEvent
+from .Profiling import logEvent 
 
 class System:
     def __init__(self):
@@ -66,9 +65,9 @@ class SO_base:
         self.dt_system = tOut - self.t_system_last
         self.t_system = self.t_system_last + self.dt_system
         self.stepSequence=[(self.t_system,m) for m in self.modelList]
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,self.dt_system),level=1)
-        log("Initializing step sequence  for system %s to %s" %
+        logEvent("Initializing step sequence  for system %s to %s" %
             (self.system.name,self.stepSequence),level=1)
     def updateTimeHistory(self):
         #update step
@@ -100,7 +99,7 @@ class SO_base:
     # def retrySequence_modelStepFailure(self):
     #     return False#don't try to recover
     def modelStepTaken(self,model,t_stepSequence):
-        log("SO_base modelStepTaken for model= %s t_system_last= %s t_model_last= %s  setting to t_stepSequence= %s " % (model.name,
+        logEvent("SO_base modelStepTaken for model= %s t_system_last= %s t_model_last= %s  setting to t_stepSequence= %s " % (model.name,
                                                                                                                          self.t_system_last,
                                                                                                                          model.stepController.t_model_last,
                                                                                                                          t_stepSequence),level=3)
@@ -170,9 +169,9 @@ class Sequential_FixedStep_Simple(SO_base):
         self.dt_system = tOut - self.t_system_last
         self.t_system = self.t_system_last + self.dt_system
         self.stepSequence=[(self.t_system,m) for m in self.modelList]
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,self.dt_system),level=1)
-        log("Initializing step sequence  for system %s to %s" %
+        logEvent("Initializing step sequence  for system %s to %s" %
             (self.system.name,self.stepSequence),level=1)
     def updateTimeHistory(self):
         #update step
@@ -209,13 +208,13 @@ class Sequential_NonUniformFixedStep(SO_base):
         else:
             if (self.dt_system > 0.0):
                 if(self.t_system_last + self.dt_system >= tExact*(1.0-self.stepExactEps)):
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = tExact - self.t_system_last
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
                 elif( tExact - (self.t_system_last + self.dt_system) < self.dt_system/2.0 ): #if next step would be within dt/2 ball go ahead and cut a little bit
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = (tExact - self.t_system_last)/2.0
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             if (self.dt_system < 0.0):
                 if(self.t_system_last + self.dt_system <= tExact*(1.0 + self.stepExactEps)):
                     self.dt_system = tExact - self.t_system_last
@@ -275,13 +274,13 @@ class Sequential_MinModelStep(SO_base):
         else:
             if (self.dt_system > 0.0):
                 if(self.t_system_last + self.dt_system >= tExact*(1.0-self.stepExactEps)):
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = tExact - self.t_system_last
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
                 elif( tExact - (self.t_system_last + self.dt_system) < self.dt_system/2.0 ): #if next step would be within dt/2 ball go ahead and cut a little bit
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = (tExact - self.t_system_last)/2.0
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             if (self.dt_system < 0.0):
                 if(self.t_system_last + self.dt_system <= tExact*(1.0 + self.stepExactEps)):
                     self.dt_system = tExact - self.t_system_last
@@ -303,7 +302,7 @@ class Sequential_MinModelStep(SO_base):
         for model in self.modelList:
             model.stepController.dt_model = self.dt_system
             model.stepController.set_dt_allLevels()
-        log("SplitOperator_Min choose_dt_system t_system_last= %s dt_system= %s t_system= %s " % (self.t_system_last,
+        logEvent("SplitOperator_Min choose_dt_system t_system_last= %s dt_system= %s t_system= %s " % (self.t_system_last,
                                                                                                   self.dt_system,
                                                                                                   self.t_system),3)
     def initialize_dt_system(self,t0,tOut):
@@ -317,11 +316,11 @@ class Sequential_MinModelStep(SO_base):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -382,11 +381,11 @@ class Sequential_MinFLCBDFModelStep(SO_base):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -453,22 +452,22 @@ class Sequential_MinAdaptiveModelStep(SO_base):
         if old:
             if (self.dt_system > 0.0 and
                 self.t_system_last + self.dt_system >=  tExact*(1.0-self.stepExactEps)):
-                log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                 self.dt_system = tExact - self.t_system_last
-                log("=========================================================dt system final" + str(self.dt_system),level=5)
+                logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             elif (self.dt_system < 0.0 and
                   self.t_system_last + self.dt_system <=  tExact*(1.0 + self.stepExactEps)):
                 self.dt_system = tExact - self.t_system_last
         else:
             if (self.dt_system > 0.0):
                 if(self.t_system_last + self.dt_system >= tExact*(1.0-self.stepExactEps)):
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = tExact - self.t_system_last
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
                 elif( tExact - (self.t_system_last + self.dt_system) < self.dt_system/2.0 ): #if next step would be within dt/2 ball go ahead and cut a little bit
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = (tExact - self.t_system_last)/2.0
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             if (self.dt_system < 0.0):
                 if(self.t_system_last + self.dt_system <= tExact*(1.0 + self.stepExactEps)):
                     self.dt_system = tExact - self.t_system_last
@@ -503,11 +502,11 @@ class Sequential_MinAdaptiveModelStep(SO_base):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -581,22 +580,22 @@ class ISO_fixed_MinAdaptiveModelStep(SO_base):
         if old:
             if (self.dt_system > 0.0 and
                 self.t_system_last + self.dt_system >=  tExact*(1.0-self.stepExactEps)):
-                log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                 self.dt_system = tExact - self.t_system_last
-                log("=========================================================dt system final" + str(self.dt_system),level=5)
+                logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             elif (self.dt_system < 0.0 and
                   self.t_system_last + self.dt_system <=  tExact*(1.0 + self.stepExactEps)):
                 self.dt_system = tExact - self.t_system_last
         else:
             if (self.dt_system > 0.0):
                 if(self.t_system_last + self.dt_system >= tExact*(1.0-self.stepExactEps)):
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = tExact - self.t_system_last
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
                 elif( tExact - (self.t_system_last + self.dt_system) < self.dt_system/2.0 ): #if next step would be within dt/2 ball go ahead and cut a little bit
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = (tExact - self.t_system_last)/2.0
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             if (self.dt_system < 0.0):
                 if(self.t_system_last + self.dt_system <= tExact*(1.0 + self.stepExactEps)):
                     self.dt_system = tExact - self.t_system_last
@@ -631,11 +630,11 @@ class ISO_fixed_MinAdaptiveModelStep(SO_base):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -710,22 +709,22 @@ class Sequential_MinAdaptiveModelStep_SS(SO_base):
         if old:
             if (self.dt_system > 0.0 and
                 self.t_system_last + self.dt_system >=  tExact*(1.0-self.stepExactEps)):
-                log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                 self.dt_system = tExact - self.t_system_last
-                log("=========================================================dt system final" + str(self.dt_system),level=5)
+                logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             elif (self.dt_system < 0.0 and
                   self.t_system_last + self.dt_system <=  tExact*(1.0 + self.stepExactEps)):
                 self.dt_system = tExact - self.t_system_last
         else:
             if (self.dt_system > 0.0):
                 if(self.t_system_last + self.dt_system >= tExact*(1.0-self.stepExactEps)):
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = tExact - self.t_system_last
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
                 elif( tExact - (self.t_system_last + self.dt_system) < self.dt_system/2.0 ): #if next step would be within dt/2 ball go ahead and cut a little bit
-                    log("===========================================================dt system orig" + str(self.dt_system),level=5)
+                    logEvent("===========================================================dt system orig" + str(self.dt_system),level=5)
                     self.dt_system = (tExact - self.t_system_last)/2.0
-                    log("=========================================================dt system final" + str(self.dt_system),level=5)
+                    logEvent("=========================================================dt system final" + str(self.dt_system),level=5)
             if (self.dt_system < 0.0):
                 if(self.t_system_last + self.dt_system <= tExact*(1.0 + self.stepExactEps)):
                     self.dt_system = tExact - self.t_system_last
@@ -765,11 +764,11 @@ class Sequential_MinAdaptiveModelStep_SS(SO_base):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -860,11 +859,11 @@ class SequentialNotInOrder_MinFLCBDFModelStep(Sequential_MinFLCBDFModelStep):
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)
@@ -919,11 +918,11 @@ class SequentialNotInOrder_MinAdaptiveModelStep(Sequential_MinAdaptiveModelStep)
             model.stepController.t_model = self.t_system
             model.stepController.set_dt_allLevels()
             model.stepController.initializeTimeHistory()
-        log("Initializing time step on system %s to dt = %12.5e" %
+        logEvent("Initializing time step on system %s to dt = %12.5e" %
             (self.system.name,
              self.dt_system),
             level=1)
-        log("Initializing step sequence for system %s to %s" %
+        logEvent("Initializing step sequence for system %s to %s" %
             (self.system.name,
              self.stepSequence),
             level=1)

--- a/proteus/StepControl.py
+++ b/proteus/StepControl.py
@@ -4,8 +4,7 @@ A class hierarchy for methods of controlling the step size
 .. inheritance-diagram:: proteus.StepControl
    :parts: 1
 """
-import Profiling
-log = Profiling.logEvent
+from .Profiling import logEvent
 #mwf add Comm for saving info about time step in separate file
 import Comm
 from flcbdfWrappers import globalMax
@@ -78,7 +77,7 @@ class SC_base:
                 self.set_dt_allLevels()
                 retry = True
             else:
-                log("Time step reduced to machine precision",level=1)
+                logEvent("Time step reduced to machine precision",level=1)
         return retry
     def retryStep_errorFailure(self):
         self.errorFailures += 1
@@ -90,11 +89,11 @@ class SC_base:
                 self.set_dt_allLevels()
                 retry = True
             else:
-                log("Time step reduced to machine precision",level=1)
+                logEvent("Time step reduced to machine precision",level=1)
         return retry
     def stepExact_model(self,tOut):
         if self.t_model > tOut - tOut*1.0e-8:
-            log("StepControl base stepExact t_model= %s tOut= %s t_model_last= %s dt_model= %s setting to %s " % (self.t_model,tOut,self.t_model_last,
+            logEvent("StepControl base stepExact t_model= %s tOut= %s t_model_last= %s dt_model= %s setting to %s " % (self.t_model,tOut,self.t_model_last,
                                                                                                                   self.dt_model,tOut-self.t_model_last),1)
             self.dt_model = tOut - self.t_model_last
             self.set_dt_allLevels()
@@ -111,7 +110,7 @@ class SC_base:
         self.set_dt_allLevels()
         #self.substeps = [self.t_model]
         self.setSubsteps([self.t_model])
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def updateSubstep(self):
@@ -225,7 +224,7 @@ class PsiTCtte_controller(SC_base):
         for levelSolver in self.model.solver.solverList:
             levelSolver.maxIts=1
             levelSolver.convergenceTest = 'its'
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def setInitialGuess(self,uList,rList):
@@ -262,7 +261,7 @@ class PsiTCtte_controller(SC_base):
             if self.substeps[-1] != self.t_model:
                 self.substeps.append(self.t_model)#set to new  time step
             else:
-                log("PsiTC converged ||res|| = %12.5e" % res)
+                logEvent("PsiTC converged ||res|| = %12.5e" % res)
         self.nssteps +=1
     def choose_dt_model(self):
         #don't modify dt_model
@@ -311,7 +310,7 @@ class Osher_controller(SC_base):
         #for levelSolver in self.model.solver.solverList:
         #    levelSolver.maxIts=1
         #    levelSolver.convergenceTest = 'its'
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def updateSubstep(self):
@@ -346,7 +345,7 @@ class Osher_controller(SC_base):
             if self.substeps[-1] != self.t_model:
                 self.substeps[-1] = self.t_model#set to new time step#.append(self.t_model)#set to new  time step
             else:
-                log("Osher converged %12.5e" % (ssError))
+                logEvent("Osher converged %12.5e" % (ssError))
             self.nSteps=0
 
     def choose_dt_model(self):
@@ -395,7 +394,7 @@ class Osher_PsiTC_controller(SC_base):
         self.t = tOut
         self.setSubsteps([tOut])
         self.nSteps=0
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def updateSubstep(self):
@@ -421,17 +420,17 @@ class Osher_PsiTC_controller(SC_base):
             self.dt_model = m.timeIntegration.dt
             if self.nSteps >= self.nStepsOsher:#start ramping up the time step
                 self.dt_model = m.timeIntegration.dt*2.0**(self.nSteps-self.nStepsOsher)
-            log("Osher-PsiTC dt %12.5e" %(self.dt_model),level=1)
+            logEvent("Osher-PsiTC dt %12.5e" %(self.dt_model),level=1)
             self.set_dt_allLevels()
             #physical time step
             self.t_model = self.substeps[0]
             self.substeps.append(self.substeps[0])
-            log("Osher-PsiTC iteration %d |res| = %12.5e" %(self.nSteps,res),level=1)
+            logEvent("Osher-PsiTC iteration %d |res| = %12.5e" %(self.nSteps,res),level=1)
         elif self.nSteps >= self.nStepsMax:
-            log("Osher-PsiTC DID NOT Converge |res| = %12.5e but quitting anyway" %(res,))
+            logEvent("Osher-PsiTC DID NOT Converge |res| = %12.5e but quitting anyway" %(res,))
             self.nSteps=0
         else:
-            log("Osher-PsiTC converged |res| = %12.5e" %(res,))
+            logEvent("Osher-PsiTC converged |res| = %12.5e" %(res,))
             self.nSteps=0
     def choose_dt_model(self):
         #don't modify dt_model
@@ -488,7 +487,7 @@ class Osher_PsiTC_controller2(SC_base):
 
 
 
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def updateSubstep(self):
@@ -516,19 +515,19 @@ class Osher_PsiTC_controller2(SC_base):
             self.dt_model = m.timeIntegration.dt
             if self.nSteps >= self.nStepsOsher:#start ramping up the time step
                 self.dt_model = self.dt_model*self.red_ratio
-            #log("Osher-PsiTC dt %12.5e" %(self.dt_model),level=1)
+            #logEvent("Osher-PsiTC dt %12.5e" %(self.dt_model),level=1)
             self.set_dt_allLevels()
             #physical time step
             self.t_model = self.substeps[0]
             self.substeps.append(self.substeps[0])
 
 
-            log("Osher-PsiTC iteration %d  dt = %12.5e  |res| = %12.5e %g  " %(self.nSteps,self.dt_model,res,(res/self.res0)*100.0),level=1)
+            logEvent("Osher-PsiTC iteration %d  dt = %12.5e  |res| = %12.5e %g  " %(self.nSteps,self.dt_model,res,(res/self.res0)*100.0),level=1)
         elif self.nSteps >= self.nStepsMax:
-            log("Osher-PsiTC DID NOT Converge |res| = %12.5e but quitting anyway" %(res,))
+            logEvent("Osher-PsiTC DID NOT Converge |res| = %12.5e but quitting anyway" %(res,))
             self.nSteps=0
         else:
-            log("Osher-PsiTC converged |res| = %12.5e %12.5e" %(res,ssError*100.0))
+            logEvent("Osher-PsiTC converged |res| = %12.5e %12.5e" %(res,ssError*100.0))
             self.nSteps=0
     def choose_dt_model(self):
         #don't modify dt_model
@@ -618,7 +617,7 @@ class Osher_FMM_controller(Osher_controller):
             if self.substeps[-1] != self.t_model:
                 self.substeps[-1] = self.t_model#set to new time step#.append(self.t_model)#set to new  time step
             else:
-                log("Osher FMM finished")
+                logEvent("Osher FMM finished")
             self.nSteps=0
 
 class Min_dt_controller(SC_base):
@@ -632,7 +631,7 @@ class Min_dt_controller(SC_base):
         self.dt_model = m.timeIntegration.dt
         self.set_dt_allLevels()
         self.substeps = [self.t_model]
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def choose_dt_model(self):
@@ -653,7 +652,7 @@ class Min_dt_controller(SC_base):
         for m in self.model.levelModelList:
             m.timeIntegration.generateSubsteps(tList)
         self.substeps = self.model.levelModelList[-1].timeIntegration.substeps
-        log("Min_dt_controller setSubsteps tList=%s self.t_model=%s self.substeps= %s " % (tList,self.t_model,self.substeps))
+        logEvent("Min_dt_controller setSubsteps tList=%s self.t_model=%s self.substeps= %s " % (tList,self.t_model,self.substeps))
 class Min_dt_RKcontroller(SC_base):
     def __init__(self,model,nOptions):
         SC_base.__init__(self,model,nOptions)
@@ -666,7 +665,7 @@ class Min_dt_RKcontroller(SC_base):
         self.set_dt_allLevels()
         #self.substeps = m.timeIntegration.substeps
         self.setSubsteps([self.t_model_last + self.dt_model])
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def choose_dt_model(self):
@@ -724,7 +723,7 @@ class Min_dt_cfl_controller(Min_dt_controller):
             self.dt_model = self.dt_model_last*self.dt_ratio_max
         self.set_dt_allLevels()
         self.substeps = [self.t_model]
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def choose_dt_model(self):
@@ -872,7 +871,7 @@ class FLCBDF_controller(SC_base):
         self.dt_model_last = self.dt_model
         self.set_dt_allLevels()
         self.setSubsteps([self.t_model])
-        log("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
+        logEvent("Initializing time step on model %s to dt = %12.5e" % (self.model.name,
                                                                    self.dt_model),
             level=1)
     def choose_dt_model(self):
@@ -1017,7 +1016,7 @@ class HeuristicNL_dt_controller(SC_base):
                 self.setSubsteps([self.t_model])
                 retry = True
             else:
-                log("Time step reduced to machine precision",level=1)
+                logEvent("Time step reduced to machine precision",level=1)
         return retry
     def retryStep_errorFailure(self):
         self.errorFailures += 1
@@ -1207,7 +1206,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
                 #for m in self.model.levelModelList:
                 #    m.timeIntegration.setInitialGuess()
             else:
-                log("Time step reduced to machine precision",level=1)
+                logEvent("Time step reduced to machine precision",level=1)
                 self.writeSolverStatisticsForStep()
         else:
             self.writeSolverStatisticsForStep()
@@ -1231,7 +1230,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
             import pdb
             pdb.set_trace()
         assert r < 1.0, "Gustaffson solver failure r= %s should have r decrease dt_in= %s alpha=%s alpha_ref=%s nnl=%s nnl_ref=%s r_a=%s, dtout=%s " % (r,dt,alpha,alpha_ref,nnl,nnl_ref,r_a,dtout)
-        log("Gustafsson solver failure dt_in= %s alpha=%s alpha_ref=%s nnl=%s nnl_ref=%s r_a=%s, dtout=%s " % (dt,alpha,alpha_ref,nnl,nnl_ref,r_a,dtout),level=1)
+        logEvent("Gustafsson solver failure dt_in= %s alpha=%s alpha_ref=%s nnl=%s nnl_ref=%s r_a=%s, dtout=%s " % (dt,alpha,alpha_ref,nnl,nnl_ref,r_a,dtout),level=1)
         return dtout
     def choose_dt_solverSuccess(self,dt):
         alpha = self.model.solver.solverList[-1].gustafsson_alpha
@@ -1245,7 +1244,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
             r_a = self.phi(alpha_ref/alpha)
         r = min(self.nonlinearGrowthRateMax,max(self.nonlinearGrowthRateMin,r_a))
         dtout = dt*r
-        log("Gustafsson solver success dt_in= %s alpha=%s alpha_ref=%s nnl=%s nnl_ref=%s r_a=%s, dtout=%s " % (dt,alpha,alpha_ref,nnl,nnl_ref,r_a,dtout),level=1)
+        logEvent("Gustafsson solver success dt_in= %s alpha=%s alpha_ref=%s nnl=%s nnl_ref=%s r_a=%s, dtout=%s " % (dt,alpha,alpha_ref,nnl,nnl_ref,r_a,dtout),level=1)
         return dtout
 
     def retryStep_errorFailure(self):
@@ -1270,10 +1269,10 @@ class GustafssonFullNewton_dt_controller(SC_base):
                 #for m in self.model.levelModelList:
                 #    m.timeIntegration.setInitialGuess()
 
-                log("Gustafsson error failure dt_e= %s dt_a=%s dt_model=%s" % (dt_e,dt_a,self.dt_model),level=1)
+                logEvent("Gustafsson error failure dt_e= %s dt_a=%s dt_model=%s" % (dt_e,dt_a,self.dt_model),level=1)
                 retry = True
             else:
-                log("Time step reduced to machine precision",level=1)
+                logEvent("Time step reduced to machine precision",level=1)
                 self.writeSolverStatisticsForStep()
 
         else:
@@ -1296,7 +1295,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
             self.errorEstimate = max(localError.values())
         else:
             self.errorEstimate = None
-        log("Gustafsson estimateError t=%s dt=%s error= %s" % (self.t_model,self.dt_model,self.errorEstimate))
+        logEvent("Gustafsson estimateError t=%s dt=%s error= %s" % (self.t_model,self.dt_model,self.errorEstimate))
 
     def choose_dt_fromError(self,dtIn):
         """
@@ -1313,7 +1312,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
             r  = self.errorSafetyFactor*(self.timeErrorTolerance/minErr)**ordInv
             r_e = min(self.errorGrowthRateMax,max(self.errorGrowthRateMin,r))
             dt_e = r_e*dtIn
-            log("Gustafsson choose_dt_fromError self t=%s dt=%s error= %s minErr= %s r_e=%s r= %s" % (self.t_model,self.dt_model,
+            logEvent("Gustafsson choose_dt_fromError self t=%s dt=%s error= %s minErr= %s r_e=%s r= %s" % (self.t_model,self.dt_model,
                                                                                                       self.errorEstimate,
                                                                                                       minErr,
                                                                                                       r_e,r))
@@ -1336,7 +1335,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
                 if m.q.has_key(('cfl',ci)):
                     maxCFL=max(maxCFL,globalMax(m.q[('cfl',ci)].max()))
                     #mwf debug
-                    log("Gustafsson cfl initial step ci = %s maxCFL= %s " % (ci,maxCFL))
+                    logEvent("Gustafsson cfl initial step ci = %s maxCFL= %s " % (ci,maxCFL))
             self.dt_model = min(self.cfl_for_initial_dt/maxCFL,m.timeIntegration.dt)
         else:
             self.dt_model = m.timeIntegration.dt
@@ -1344,7 +1343,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
         self.dt_model = min(self.dt_model,1.0e-3*(tOut-t0))
         self.set_dt_allLevels()
         self.setSubsteps([self.t_model])
-        log("Gustafsson Initializing time step on model %s to dt = %12.5e t_model_last= %s" % (self.model.name,
+        logEvent("Gustafsson Initializing time step on model %s to dt = %12.5e t_model_last= %s" % (self.model.name,
                                                                                                self.dt_model,
                                                                                                self.t_model_last),
             level=1)
@@ -1364,9 +1363,9 @@ class GustafssonFullNewton_dt_controller(SC_base):
             self.dt_model = dt_a
         self.set_dt_allLevels()
         self.setSubsteps([self.t_model])
-        log("Gustafsson choose_dt_model dt_e= %s dt_a=%s t_model_last= %s dt_model=%s t_model= %s" % (dt_e,dt_a,self.t_model_last,self.dt_model,self.t_model),level=1)
+        logEvent("Gustafsson choose_dt_model dt_e= %s dt_a=%s t_model_last= %s dt_model=%s t_model= %s" % (dt_e,dt_a,self.t_model_last,self.dt_model,self.t_model),level=1)
     def updateTimeHistory(self,resetFromDOF=False):
-        log("Gustafsson updateTimeHistory t_model_last= %s dt_model=%s t_model=%s" % (self.t_model_last,self.dt_model,self.t_model),level=1)
+        logEvent("Gustafsson updateTimeHistory t_model_last= %s dt_model=%s t_model=%s" % (self.t_model_last,self.dt_model,self.t_model),level=1)
         self.writeSolverStatisticsForStep()
         self.solverFailures=0
         self.errorFailures=0
@@ -1400,7 +1399,7 @@ class GustafssonFullNewton_dt_controller(SC_base):
 
     def stepExact_model(self,tOut):
         if self.t_model > tOut - tOut*1.0e-8:
-            log("StepControl Gustafsson stepExact t_model= %s tOut= %s t_model_last= %s dt_model= %s setting to %s " % (self.t_model,tOut,self.t_model_last,
+            logEvent("StepControl Gustafsson stepExact t_model= %s tOut= %s t_model_last= %s dt_model= %s setting to %s " % (self.t_model,tOut,self.t_model_last,
                                                                                                                   self.dt_model,tOut-self.t_model_last),1)
             self.dt_model = tOut - self.t_model_last
             self.set_dt_allLevels()

--- a/proteus/SubsurfaceTransportCoefficients.py
+++ b/proteus/SubsurfaceTransportCoefficients.py
@@ -7,8 +7,7 @@ TransportCoefficients for flow and transport in porous media
 from math import *
 from TransportCoefficients import TC_base
 import numpy
-import Profiling
-log = Profiling.logEvent
+from .Profiling import logEvent
 from proteus import FemTools
 from proteus import Transport
 import subsurfaceTransportFunctions as stfuncs
@@ -742,7 +741,7 @@ class RE_NCP1_OneLevelTransport(Transport.OneLevelTransport):
 #                 kv = kv0
 #             if self.testIsTrial:
 #                 if kv in sd.keys():
-#                     log("Shallow copy of trial shape is being used for test shape %s " % kw[0],level=4)
+#                     logEvent("Shallow copy of trial shape is being used for test shape %s " % kw[0],level=4)
 #                     sd[kw] = sd[kv]
 #                     aliased=True
 #             return aliased
@@ -755,7 +754,7 @@ class RE_NCP1_OneLevelTransport(Transport.OneLevelTransport):
 #             k0 = (ks,)+(refi,)
 #             if self.reuse_test_trial_quadrature and refi != None:
 #                 if k0 in sd.keys():
-#                     log("Shallow copy of trial shape %s is being used for trial shape %s" % (k0,k),level=4)
+#                     logEvent("Shallow copy of trial shape %s is being used for trial shape %s" % (k0,k),level=4)
 #                     sd[k] = sd[k0]
 #                     aliased=True
 #             return aliased
@@ -773,7 +772,7 @@ class RE_NCP1_OneLevelTransport(Transport.OneLevelTransport):
 #         for k in trial_shape_quadrature_duplicate:
 #             self.u_ip[k] = self.u_ip[trial_shape_quadrature_duplicate_map[k]]
 #         #mwf trial-dup end
-#         log(memory("solution interpolation points, test/trial functions trial_shape","OneLevelTransport"),level=4)
+#         logEvent(memory("solution interpolation points, test/trial functions trial_shape","OneLevelTransport"),level=4)
 #         #allocate test shape functions
 #         for k in self.test_shape_quadrature:
 #             if not makeAlias(self.u_ip,k):
@@ -782,7 +781,7 @@ class RE_NCP1_OneLevelTransport(Transport.OneLevelTransport):
 #                      self.n_u_ip_element,
 #                      self.nDOF_test_element[k[-1]]),
 #                     'd')
-#         log(memory("solution interpolation points, test/trial functions test_shape","OneLevelTransport"),level=4)
+#         logEvent(memory("solution interpolation points, test/trial functions test_shape","OneLevelTransport"),level=4)
 #         #allocate trial shape function gradients
 #         for k in sorted(self.trial_shapeGradient_quadrature):
 #             if not makeAliasForComponent1(self.u_ip,k,['grad(v)'],refi=0):#need to handle multiple component combinations
@@ -792,7 +791,7 @@ class RE_NCP1_OneLevelTransport(Transport.OneLevelTransport):
 #                      self.nDOF_trial_element[k[-1]],
 #                      self.nSpace_global),
 #                     'd')
-#         log(memory("solution interpolation points, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
+#         logEvent(memory("solution interpolation points, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
 #         #allocate test shape function gradients
 #         for k in self.test_shapeGradient_quadrature:
 #             if not makeAlias(self.u_ip,k):
@@ -3950,7 +3949,7 @@ class IncompressibleFractionalFlowSaturationMualemVanGenuchtenSplitAdvDiff(Incom
             #tLastSave =self.satModel_me.timeIntegration.tLast
             #todo need to do make sure mass conserved, handle projection from cg to dg correctly
             #todo ExplicitRK is getting messed up here, going twice as fast
-            log("Incomp.FracFlowSatAdvDiff preStep t= %s model %s setting its solution from model %s " % (t,self.satModel_me,self.satModel_other),level=2)
+            logEvent("Incomp.FracFlowSatAdvDiff preStep t= %s model %s setting its solution from model %s " % (t,self.satModel_me,self.satModel_other),level=2)
             #if self.satModelIndex_me != 1:#mwf hack
             self.satModel_other.u[0].getValues(self.u_ip[('v_other',0)],
                                                self.u_ip[('u_other',0)])

--- a/proteus/TimeIntegration.py
+++ b/proteus/TimeIntegration.py
@@ -7,7 +7,7 @@ A class hierarchy of time discretizations
 from LinearAlgebraTools import *
 import sys,math
 import Profiling
-log = Profiling.logEvent
+from .Profiling import logEvent
 from flcbdfWrappers import globalMax
 
 class TI_base:
@@ -391,7 +391,7 @@ class FLCBDF(TI_base):
     def initialize_dt(self,t0,tOut,q):
         self.tLast = t0
         self.dt = min([self.flcbdf[ci].initialize_dt(t0,tOut,q[('m',ci)],q[('mt',ci)]) for ci in self.massComponents])
-        log("Warning!!! FLDBDF initial dt will be different in parallel until we fix estimate_mt!")
+        logEvent("Warning!!! FLDBDF initial dt will be different in parallel until we fix estimate_mt!")
         #mwf hack
         #import Comm
         #comm = Comm.get()
@@ -403,13 +403,13 @@ class FLCBDF(TI_base):
         for ci in range(self.nc): self.flcbdf[('u',ci)].initialize_dt(t0,tOut,self.transport.u[ci].dof,self.Ddof_Dt[ci])
         self.t = self.tLast + self.dt
     def initializeTimeHistory(self,resetFromDOF=False):
-        log("Initializing FLCBDF time history")
+        logEvent("Initializing FLCBDF time history")
         self.initCalls +=1
         for ci in self.massComponents:
             self.flcbdf[ci].initializeTimeHistory(self.transport.q[('m',ci)],self.transport.q[('mt',ci)])
         for ci in range(self.nc): self.flcbdf[('u',ci)].initializeTimeHistory(self.transport.u[ci].dof,self.Ddof_Dt[ci])
     def calculateCoefs(self):
-        log("Calculating alpha_bdf and beta_bdf for FLCBDF")
+        logEvent("Calculating alpha_bdf and beta_bdf for FLCBDF")
         for ci in self.massComponents:
             self.alpha_bdf = self.flcbdf[ci].getCurrentAlpha()
             self.flcbdf[ci].calculate_yprime(self.beta_bdf_dummy,self.beta_bdf_dummy,self.beta_bdf[ci],self.beta_bdf_dummy2)
@@ -437,7 +437,7 @@ class FLCBDF(TI_base):
                     q[('dmt',ci,cj)].flat[:] = q[('dm',ci,cj)].flat
                     q[('dmt',ci,cj)] *= alpha
                     #mwf debug
-                    log("FLCBDF calculateElementCoefficients t= %s dt= %s alpha= %s " % (self.t,self.dt,alpha))
+                    logEvent("FLCBDF calculateElementCoefficients t= %s dt= %s alpha= %s " % (self.t,self.dt,alpha))
                 if q.has_key(('dmt_sge',ci,cj)):
                     #mwf debug
                     #import pdb
@@ -463,18 +463,18 @@ class FLCBDF(TI_base):
         for ci in range(self.nc):
             self.flcbdf[('u',ci)].calculate_yprime(self.transport.u[ci].dof,self.dummy[ci],self.Ddof_Dt[ci],self.dummy[ci])
     def choose_dt(self):
-        log("choosing dt for FLCBDF")
+        logEvent("choosing dt for FLCBDF")
         self.dt = min([self.flcbdf[ci].choose_dt(self.tLast,self.tLast+100.0*self.dt) for ci in self.massComponents])
         for ci in range(self.nc): self.flcbdf[('u',ci)].choose_dt(self.tLast,self.tLast+100.0*self.dt)
         self.t = self.tLast + self.dt
     def set_dt(self,DTSET):
-        log("setting dt for FLCBDF")
+        logEvent("setting dt for FLCBDF")
         self.dt = DTSET
         self.t = self.tLast + self.dt
         for ci in self.massComponents: self.flcbdf[ci].set_dt(DTSET)
         for ci in range(self.nc): self.flcbdf[('u',ci)].set_dt(DTSET)
     def updateTimeHistory(self,resetFromDOF=False):
-        log("updating time history for FLCBDF")
+        logEvent("updating time history for FLCBDF")
         self.tLast = self.t
         for ci in self.massComponents: self.flcbdf[ci].stepTaken(self.m[ci])
         for ci in range(self.nc): self.flcbdf[('u',ci)].stepTaken(self.transport.u[ci].dof)
@@ -491,7 +491,7 @@ class FLCBDF(TI_base):
         """
         pass
     def lastStepErrorOk(self):
-        log("checking error for FLCBDF")
+        logEvent("checking error for FLCBDF")
         OK=True
         for ci in self.massComponents:
             OK = (OK and bool(self.flcbdf[ci].lastStepErrorOk(self.m[ci])))
@@ -551,7 +551,7 @@ class PsiTCtte(BackwardEuler_cfl):
         self.tLast = self.t
         #mwf to check how many times update history called
         if self.updateHistoryJustCalled:
-            log("""WARNING PsiTCtte in updateHistory historyJustCalled is True
+            logEvent("""WARNING PsiTCtte in updateHistory historyJustCalled is True
 dt_history[0]=%g dt_history[1]=%g nsteps=%d """ %(self.dt_history[0],self.dt_history[1],
                                                   self.nsteps))
 
@@ -602,7 +602,7 @@ class PsiTCtte_new(BackwardEuler):
             self.dt_history[1] = self.dt_history[0]
             self.dt_history[0] = self.dt
             self.nsteps+=1
-            log("PsiTC (first 2 steps) choose_dt dt=%f" % self.dt)
+            logEvent("PsiTC (first 2 steps) choose_dt dt=%f" % self.dt)
             return
         dtmax = 0.0
         for ci in self.massComponents:
@@ -620,7 +620,7 @@ class PsiTCtte_new(BackwardEuler):
             self.m_last[ci].flat[:] = self.m_tmp[ci].flat
             self.mt_history[1][ci].flat[:]= self.mt_history[0][ci].flat[:]
             self.mt_history[0][ci].flat[:]= self.mt_tmp[ci].flat[:]
-        log("PsiTC choose_dt dt=%f" % self.dt)
+        logEvent("PsiTC choose_dt dt=%f" % self.dt)
     def resetTimeHistory(self,resetFromDOF=False):
         for ci in self.massComponents:
             self.m_last[ci].flat[:] = self.m_tmp[ci].flat
@@ -1374,7 +1374,7 @@ class VBDF(TI_base):
         #pdb.set_trace()
         self.calculateCoefs()
         #mwf debug
-        log("VBDF calculateElementCoefficients t= %s dt= %s alpha= %s " % (self.t,self.dt,self.alpha_bdf))
+        logEvent("VBDF calculateElementCoefficients t= %s dt= %s alpha= %s " % (self.t,self.dt,self.alpha_bdf))
         for ci in self.massComponents:
             self.m_tmp[ci][:] = q[('m',ci)]
             self.mt_tmp[ci][:]= q[('m',ci)]#self.alpha_bdf*q[('m',ci)]
@@ -1396,7 +1396,7 @@ class VBDF(TI_base):
 
         Controller now has to take care of self.t and self.dt
         """
-        log("VBDF initialize_dt tLast= %s t=%s dt=%s t0=%s tOut=%s " % (self.tLast,self.t,self.dt,t0,tOut))
+        logEvent("VBDF initialize_dt tLast= %s t=%s dt=%s t0=%s tOut=%s " % (self.tLast,self.t,self.dt,t0,tOut))
         self.tLast=t0
         self.t = tOut
         self.dt = tOut - t0
@@ -1428,7 +1428,7 @@ class VBDF(TI_base):
         self.computeErrorEstimate()
         return True
     def initializeTimeHistory(self,resetFromDOF=True):
-        log("VBDF initialTimeHistory call %s tLast=%s t=%s dt= %s dt_history[0] = %s " % (self.nUpdatesTimeHistoryCalled,
+        logEvent("VBDF initialTimeHistory call %s tLast=%s t=%s dt= %s dt_history[0] = %s " % (self.nUpdatesTimeHistoryCalled,
                                                                                           self.tLast,self.t,self.dt,self.dt_history[0]),1)
         for n in range(self.max_order-1):
             for ci in self.massComponents:
@@ -1445,7 +1445,7 @@ class VBDF(TI_base):
         #self.computeErrorEstimate()
         self.nUpdatesTimeHistoryCalled  += 1
         #what to do about first call?, getting multiple calls
-        log("VBDF updateTimeHistory call %s tLast=%s t=%s dt= %s dt_history[0] = %s " % (self.nUpdatesTimeHistoryCalled,
+        logEvent("VBDF updateTimeHistory call %s tLast=%s t=%s dt= %s dt_history[0] = %s " % (self.nUpdatesTimeHistoryCalled,
                                                                                                self.tLast,self.t,self.dt,self.dt_history[0]),1)
         self.tLast = self.t
         for n in range(self.max_order-1):
@@ -1507,7 +1507,7 @@ class VBDF(TI_base):
             self.m_pred[ci].flat[:] = self.mt_history[0][ci].flat
             self.m_pred[ci]   *= self.dt
             self.m_pred[ci]   += self.m_history[0][ci]
-        log("VBDF calculatePredictor tLast= %s t= %s dt= %s " % (self.tLast,self.t,self.dt),1)
+        logEvent("VBDF calculatePredictor tLast= %s t= %s dt= %s " % (self.tLast,self.t,self.dt),1)
 
     def calculateCoefs(self):
         if self.needToCalculateBDFCoefs:
@@ -1751,7 +1751,7 @@ class ExplicitRK_base(TI_base):
         if self.lstage < self.nStages:
             self.t = self.substeps[self.lstage]
         if self.lstage < 0 or self.lstage > self.nStages:
-            log("""stage= %d out of allowed bounds [0,%d]""" % (self.lstage,self.nStages))
+            logEvent("""stage= %d out of allowed bounds [0,%d]""" % (self.lstage,self.nStages))
     def calculateElementCoefficients(self,q):
         """
         set m_t as
@@ -1760,12 +1760,12 @@ class ExplicitRK_base(TI_base):
 
         """
         if self.dt <= 1.0e-24:
-            log('WARNING dt= ',self.dt,' too small in updateElementCoefficients quitting ')
+            logEvent('WARNING dt= ',self.dt,' too small in updateElementCoefficients quitting ')
             sys.exit(1)
         if self.usingDTinMass == False:
             return self.calculateElementCoefficientsNoDtInMass(q)
         #mwf debug
-        log("""ExplicitRKbase calcElemenCoefs lstage= %d nStages= %d dt= %s """ % (self.lstage,self.nStages,self.dt))
+        logEvent("""ExplicitRKbase calcElemenCoefs lstage= %d nStages= %d dt= %s """ % (self.lstage,self.nStages,self.dt))
         #import pdb
         #pdb.set_trace()
         for ci in range(self.nc):#loop through components
@@ -1776,7 +1776,7 @@ class ExplicitRK_base(TI_base):
                     q[('mt',ci)].flat[:]-= self.alpha[self.lstage,i]*self.stageValues['m'][ci][i].flat[:]
                 #end i loop through stages
                 #mwf debug
-                log("""ExplicitRKbase calcElemenCoefs lstage= %d nStages= %d max dt diff= %s """ % (self.lstage,self.nStages,max(numpy.absolute(q[('mt',0)].flat))))
+                logEvent("""ExplicitRKbase calcElemenCoefs lstage= %d nStages= %d max dt diff= %s """ % (self.lstage,self.nStages,max(numpy.absolute(q[('mt',0)].flat))))
                 #if max(numpy.absolute(q[('mt',0)].flat)) > 1.0e-6:
                 #    import pdb
                 #    pdb.set_trace()
@@ -1798,7 +1798,7 @@ class ExplicitRK_base(TI_base):
         """
         assert self.dt > 1.0e-24,"dt = %d too small in calculateElementCoefficients" % self.dt
         #mwf debug
-        log("""ExplicitRK calcElemenCoefsNoDt lstage= %d nStages= %d""" % (self.lstage,self.nStages))
+        logEvent("""ExplicitRK calcElemenCoefsNoDt lstage= %d nStages= %d""" % (self.lstage,self.nStages))
         for ci in range(self.nc):#loop through components
             if q.has_key(('m',ci)):
                 self.stageValues['m'][ci][self.lstage+1].flat[:] = q[('m',ci)].flat[:]
@@ -1983,8 +1983,8 @@ class ExplicitRK_base(TI_base):
             #self.substeps.append(t)#always end up at t^{n+1}
             tLast = t
             #mwf debug
-            log('Explicit RK dcoefs= %s substeps = %s ' % (self.dcoefs,self.substeps))
-            log('Explicit RK t= %s tLast=%s self.tLast= %s ' % (t,tLast,self.tLast))
+            logEvent('Explicit RK dcoefs= %s substeps = %s ' % (self.dcoefs,self.substeps))
+            logEvent('Explicit RK t= %s tLast=%s self.tLast= %s ' % (t,tLast,self.tLast))
     def setInitialStageValues(self):
         """
         setup all the stage values if we assume that the initial condition
@@ -2042,7 +2042,7 @@ class ExplicitRK_base(TI_base):
             if 'nStagesTime' in dir(nOptions):
                 self.resetOrder(nOptions.timeOrder,nOptions.nStagesTime)
             else:
-                log("WARNING ExplicitRK.setFromOptions assuming nStagesTime=timeOrder")
+                logEvent("WARNING ExplicitRK.setFromOptions assuming nStagesTime=timeOrder")
                 self.resetOrder(nOptions.timeOrder,nOptions.timeOrder)
 
 
@@ -2251,7 +2251,7 @@ class SSPRKPIintegration(ExplicitRK_base):
                 #        for i in range(self.transport.u[ci].femSpace.dofMap.l2g.shape[1]):
                 #            self.transport.u[ci].dof[self.transport.u[ci].femSpace.dofMap.l2g[eN,i]] = 0.0
                 #    u.flat[:] = self.transport.u[ci].dof.flat[:]
-                #    log("Min_dt_RKcontroller performing scatter forward t= %s " % self.t)
+                #    logEvent("Min_dt_RKcontroller performing scatter forward t= %s " % self.t)
                 #    par_u.scatter_forward_insert()
                 #    self.transport.u[ci].dof.flat[:] = u.flat[:]
         #if
@@ -3610,7 +3610,7 @@ class ForwardIntegrator:
         t = tIn
         failedFlag = False
         if self.dtMeth == NoIntegration:
-            log("""NoIntegration, fint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
+            logEvent("""NoIntegration, fint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
 
             failedFlag=self.mlNL.solveMultilevel(uList=self.mlvTran.uList,
                                                  rList=self.mlvTran.rList,
@@ -3620,7 +3620,7 @@ class ForwardIntegrator:
             self.tLast = tOut
             t = tOut
             self.mlvTran.updateTimeHistory(t)
-            log("""fint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
+            logEvent("""fint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
             self.mlvTran.choose_dt(DTSET=self.dtSET,tOut=tOut)
             #mwf debug
             #print """after solve failedFlag= %s """ % failedFlag
@@ -3631,7 +3631,7 @@ class ForwardIntegrator:
                 self.firstStep=False
             while t < tOut and failedFlag== False:
                 #mwf debug
-                log("""\nfint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
+                logEvent("""\nfint t=%g tOut=%g DTSET=%s DT=%g """ % (t,tOut,self.dtSET,self.mlvTran.dt))
                 #try not to step past tOut
 #                 if self.stepExact and abs(t+self.mlvTran.dt-tOut) < 1.0e-10 or t+self.mlvTran.dt > tOut+1.0e-10:
 #                     self.mlvTran.resetDT()
@@ -3754,7 +3754,7 @@ class SteadyStateIntegrator(ForwardIntegrator):
         #end dtMeth
         #force number of stages to be 1
         if not (self.dtMeth == NoIntegration or self.dtMeth == PsiTCtte):
-            log("""WARNING SteadyStateIntegrator type= %s must be NoIntegration or
+            logEvent("""WARNING SteadyStateIntegrator type= %s must be NoIntegration or
 PsiTCtte!""" % self.dtMeth)
     def calculateSolution(self,tIn,tOut):
         """
@@ -3878,7 +3878,7 @@ PsiTCtte!""" % self.dtMeth)
         #mwf hack
         if self.ignoreFailure and not converged:
             if failedFlag:
-                log("""SteadyStateIntegrator ignoredFailure t=%s """ % tOut)
+                logEvent("""SteadyStateIntegrator ignoredFailure t=%s """ % tOut)
             #undo any damage. this will get propagated to the other grids and u-list in the projection
             for j,uj in enumerate(self.mlvTran.modelList[-1].u.values()):
                 uj.dof[:] = self.u_dof_save[j][:]

--- a/proteus/Transport.py
+++ b/proteus/Transport.py
@@ -20,15 +20,13 @@ import Quadrature
 from TimeIntegration import *
 from NonlinearSolvers import *
 import cfemIntegrals
-import Profiling
 from TransportCoefficients import *
 import NumericalFlux
 import cnumericalFlux
 import Comm
 import flcbdfWrappers
 import cmeshTools
-
-log = Profiling.logEvent
+from .Profiling import logEvent
 
 class StorageSet(set):
     def __init__(self,initializer=[],shape=(0,),storageType='d'):
@@ -259,7 +257,7 @@ class OneLevelTransport(NonlinearEquation):
                     if not coefficients.sdInfo.has_key((ci,ck)):
                         coefficients.sdInfo[(ci,ck)] = (numpy.arange(start=0,stop=self.nSpace_global**2+1,step=self.nSpace_global,dtype='i'),
                                                         numpy.array([range(self.nSpace_global) for row in range(self.nSpace_global)],dtype='i'))
-                    log("Sparse diffusion information key "+`(ci,ck)`+' = '+`coefficients.sdInfo[(ci,ck)]`)
+                    logEvent("Sparse diffusion information key "+`(ci,ck)`+' = '+`coefficients.sdInfo[(ci,ck)]`)
         #
         NonlinearEquation.__init__(self,self.nFreeVDOF_global)
         #
@@ -776,7 +774,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nSpace_global,
                      self.nSpace_global),
                     'd')
-        log(memory("element quadrature","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature","OneLevelTransport"),level=4)
         #
         # element boundary quadrature
         #
@@ -826,7 +824,7 @@ class OneLevelTransport(NonlinearEquation):
                                            max(1,self.nSpace_global-1),
                                            max(1,self.nSpace_global-1)),
                                           'd')
-            log(memory("element boundary quadrature","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature","OneLevelTransport"),level=4)
         #
         # exterior element boundary quadrature
         #
@@ -861,7 +859,7 @@ class OneLevelTransport(NonlinearEquation):
                                        max(1,self.nSpace_global-1),
                                        max(1,self.nSpace_global-1)),
                                       'd')
-        log(memory("global exterior element boundary quadrature","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature","OneLevelTransport"),level=4)
         self.forceStrongConditions= numericalFluxType.useStrongDirichletConstraints
         self.dirichletConditionsForceDOF = {}
         if self.forceStrongConditions:
@@ -887,7 +885,7 @@ class OneLevelTransport(NonlinearEquation):
             self.scalars_elementBoundaryQuadrature_global.allocate(self.ebq_global)
             #allocate vectors element boundary quadrature global
             self.vectors_elementBoundaryQuadrature_global.allocate(self.ebq_global)
-            log(memory("element boundary quadrature global","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature global","OneLevelTransport"),level=4)
         #
         # phi interpolation points
         #
@@ -966,7 +964,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nSpace_global),
                         'd')
 
-        log(memory("interpolation points","OneLevelTransport"),level=4)
+        logEvent(memory("interpolation points","OneLevelTransport"),level=4)
         #
         # shape
         #
@@ -979,7 +977,7 @@ class OneLevelTransport(NonlinearEquation):
                 kv = kv0
             if self.testIsTrial:
                 if kv in sd.keys():
-                    log("Shallow copy of trial shape is being used for test shape %s " % kw[0],level=4)
+                    logEvent("Shallow copy of trial shape is being used for test shape %s " % kw[0],level=4)
                     sd[kw] = sd[kv]
                     aliased=True
             return aliased
@@ -992,7 +990,7 @@ class OneLevelTransport(NonlinearEquation):
             k0 = (ks,)+(refi,)
             if self.reuse_test_trial_quadrature and refi != None:
                 if k0 in sd.keys():
-                    log("Shallow copy of trial shape %s is being used for trial shape %s" % (k0,k),level=4)
+                    logEvent("Shallow copy of trial shape %s is being used for trial shape %s" % (k0,k),level=4)
                     sd[k] = sd[k0]
                     aliased=True
             return aliased
@@ -1018,7 +1016,7 @@ class OneLevelTransport(NonlinearEquation):
         for k in trial_shape_quadrature_duplicate:
             self.q[k] = self.q[trial_shape_quadrature_duplicate_map[k]]
         #mwf trial-dup end
-        log(memory("element quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
         #allocate phi trial shape functions
         refComponent_phi = findReferenceComponent_phi(self.coefficients.diffusion)
         for k in sorted(self.phi_trial_shape_quadrature):
@@ -1028,7 +1026,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nQuadraturePoints_element,
                      self.nDOF_phi_trial_element[k[-1]]),
                     'd')
-        log(memory("element quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
         #allocate test shape functions
         for k in self.test_shape_quadrature:
             if not makeAlias(self.q,k):
@@ -1037,7 +1035,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nQuadraturePoints_element,
                      self.nDOF_test_element[k[-1]]),
                     'd')
-        log(memory("element quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
         #allocate trial shape function gradients
         for k in sorted(self.trial_shapeGradient_quadrature):
             if not makeAliasForComponent1(self.q,k,['grad(v)'],refi=0):#need to handle multiple component combinations
@@ -1047,7 +1045,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_trial_element[k[-1]],
                      self.nSpace_global),
                     'd')
-        log(memory("element quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
         #allocate phi trial shape function gradients
         for k in sorted(self.phi_trial_shapeGradient_quadrature):
             if not makeAliasForComponent1(self.q,k,['grad(v)'],refi=refComponent_phi):
@@ -1057,7 +1055,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_phi_trial_element[k[-1]],
                      self.nSpace_global),
                     'd')
-        log(memory("element quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
         #allocate test shape function gradients
         for k in self.test_shapeGradient_quadrature:
             if not makeAlias(self.q,k):
@@ -1088,7 +1086,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nSpace_global,
                          self.nSpace_global),
                         'd')
-        log(memory("element quadrature, test/trial functions test_shapeGradient","OneLevelTransport"),level=4)
+        logEvent(memory("element quadrature, test/trial functions test_shapeGradient","OneLevelTransport"),level=4)
         if not self.lowmem:
             #allocate trial shape function X test shape functions
             for k in self.trial_shape_X_test_shape_quadrature:
@@ -1098,7 +1096,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_trial_element[k[1]],
                      self.nDOF_test_element[k[2]]),
                     'd')
-            log(memory("element quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
             #allocate phi trial shape function X test shape functions
             for k in self.phi_trial_shape_X_test_shape_quadrature:
                 self.q[k]=numpy.zeros(
@@ -1107,7 +1105,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_phi_trial_element[k[1]],
                      self.nDOF_test_element[k[2]]),
                     'd')
-            log(memory("element quadrature, test/trial functions phi_trial_shape_X_test_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions phi_trial_shape_X_test_shape","OneLevelTransport"),level=4)
             #allocate gradient X test shape function gradients
             for k in self.gradient_X_test_shapeGradient_quadrature:
                 self.q[k]=numpy.zeros(
@@ -1117,7 +1115,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nSpace_global,
                      self.nSpace_global),
                     'd')
-            log(memory("element quadrature, test/trial functions gradient_X_test_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions gradient_X_test_shapeGradient","OneLevelTransport"),level=4)
             #allocate trial shape function X shape function gradients
             for k in self.trial_shape_X_test_shapeGradient_quadrature:
                 self.q[k]=numpy.zeros(
@@ -1127,7 +1125,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_test_element[k[2]],
                      self.nSpace_global),
                     'd')
-            log(memory("element quadrature, test/trial functions trial_shape_X_test_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions trial_shape_X_test_shapeGradient","OneLevelTransport"),level=4)
             #
             #allocate trial shape function gradient X test shape function
             for k in self.trial_shapeGradient_X_test_shape_quadrature:
@@ -1138,7 +1136,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_test_element[k[2]],
                      self.nSpace_global),
                     'd')
-            log(memory("element quadrature, test/trial functions trial_shapeGradient_X_test_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions trial_shapeGradient_X_test_shape","OneLevelTransport"),level=4)
 
             #allocate trial shape function gradient X test shape function gradients
             for k in self.trial_shapeGradient_X_test_shapeGradient_quadrature:
@@ -1150,7 +1148,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nSpace_global,
                      self.nSpace_global),
                     'd')
-            log(memory("element quadrature, test/trial functions trial_shapeGradient_X_test_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions trial_shapeGradient_X_test_shapeGradient","OneLevelTransport"),level=4)
             #allocate phi trial shape function gradient X test shape function gradients
             for k in self.phi_trial_shapeGradient_X_test_shapeGradient_quadrature:
                 self.q[k]=numpy.zeros(
@@ -1161,7 +1159,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nSpace_global,
                      self.nSpace_global),
                     'd')
-            log(memory("element quadrature, test/trial functions phi_trial_shapeGradient_X_test_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element quadrature, test/trial functions phi_trial_shapeGradient_X_test_shapeGradient","OneLevelTransport"),level=4)
         #
         # element boundary quadrature
         #
@@ -1175,7 +1173,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nElementBoundaryQuadraturePoints_elementBoundary,
                          self.nDOF_trial_element[k[-1]]),
                         'd')
-            log(memory("element boundary quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
             #allocate phi trial shape element boundary quadrature
             for k in sorted(self.phi_trial_shape_elementBoundaryQuadrature):
                 if not makeAliasForComponent1(self.ebq,k,['v'],refi=refComponent_phi):
@@ -1185,7 +1183,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nElementBoundaryQuadraturePoints_elementBoundary,
                          self.nDOF_phi_trial_element[k[-1]]),
                         'd')
-            log(memory("element boundary quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
             #allocate test shape element boundary quadrature
             for k in self.test_shape_elementBoundaryQuadrature:
                 if not makeAlias(self.ebq,k):
@@ -1195,7 +1193,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nElementBoundaryQuadraturePoints_elementBoundary,
                          self.nDOF_test_element[k[-1]]),
                         'd')
-            log(memory("element boundary quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
             #allocate trial shape gradient element boundary quadrature
             for k in sorted(self.trial_shapeGradient_elementBoundaryQuadrature):
                 if not makeAliasForComponent1(self.ebq,k,['grad(v)'],refi=0):
@@ -1206,7 +1204,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nDOF_trial_element[k[-1]],
                          self.nSpace_global),
                         'd')
-            log(memory("element boundary quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
             #allocate phi trial shape gradient element boundary quadrature
             for k in sorted(self.phi_trial_shapeGradient_elementBoundaryQuadrature):
                 if not makeAliasForComponent1(self.ebq,k,['grad(v)'],refi=refComponent_phi):
@@ -1217,7 +1215,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nDOF_phi_trial_element[k[-1]],
                          self.nSpace_global),
                         'd')
-            log(memory("element boundary quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
+            logEvent(memory("element boundary quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
             #allocate trial shape X test shape element boundary quadratre
             if not self.lowmem:
                 for k in self.trial_shape_X_test_shape_elementBoundaryQuadrature:
@@ -1228,7 +1226,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nDOF_trial_element[k[1]],
                          self.nDOF_test_element[k[2]]),
                         'd')
-                log(memory("element boundary quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
+                logEvent(memory("element boundary quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
         #
         # global exterior element boundary quadrature
         #
@@ -1241,7 +1239,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nElementBoundaryQuadraturePoints_elementBoundary,
                      self.nDOF_trial_element[k[-1]]),
                     'd')
-        log(memory("global exterior element boundary quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature, test/trial functions trial_shape","OneLevelTransport"),level=4)
         #allocate phi trial shape element boundary quadrature
         for k in sorted(self.phi_trial_shape_elementBoundaryQuadrature):
             if not makeAliasForComponent1(self.ebqe,k,['v'],refi=refComponent_phi):
@@ -1250,7 +1248,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nElementBoundaryQuadraturePoints_elementBoundary,
                      self.nDOF_phi_trial_element[k[-1]]),
                     'd')
-        log(memory("global exterior element boundary quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature, test/trial functions phi_trial_shape","OneLevelTransport"),level=4)
         #allocate test shape element boundary quadrature
         for k in self.test_shape_elementBoundaryQuadrature:
             if not makeAlias(self.ebqe,k):
@@ -1259,7 +1257,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nElementBoundaryQuadraturePoints_elementBoundary,
                      self.nDOF_test_element[k[-1]]),
                     'd')
-        log(memory("global exterior element boundary quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature, test/trial functions test_shape","OneLevelTransport"),level=4)
         #allocate trial shape gradient element boundary quadrature
         for k in sorted(self.trial_shapeGradient_elementBoundaryQuadrature):
             if not makeAliasForComponent1(self.ebqe,k,['grad(v)'],refi=0):
@@ -1269,7 +1267,7 @@ class OneLevelTransport(NonlinearEquation):
                  self.nDOF_trial_element[k[-1]],
                  self.nSpace_global),
                 'd')
-        log(memory("global exterior element boundary quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature, test/trial functions trial_shapeGradient","OneLevelTransport"),level=4)
         #allocate phi trial shape gradient element boundary quadrature
         for k in sorted(self.phi_trial_shapeGradient_elementBoundaryQuadrature):
             #if not makeAlias(self.ebqe,k):
@@ -1280,7 +1278,7 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_phi_trial_element[k[-1]],
                      self.nSpace_global),
                     'd')
-        log(memory("global exterior element boundary quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
+        logEvent(memory("global exterior element boundary quadrature, test/trial functions phi_trial_shapeGradient","OneLevelTransport"),level=4)
         #allocate trial shape X test shape element boundary quadratre
         if not self.lowmem:
             for k in self.trial_shape_X_test_shape_elementBoundaryQuadrature:
@@ -1290,18 +1288,18 @@ class OneLevelTransport(NonlinearEquation):
                      self.nDOF_trial_element[k[1]],
                      self.nDOF_test_element[k[2]]),
                     'd')
-            log(memory("global exterior element boundary quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
-        log("Dumping quadrature shapes for model %s" % self.name,level=9)
-        log("Element quadrature array (q)", level=9)
-        for (k,v) in self.q.iteritems(): log(str((k,v.shape)),level=9)
-        log("Element boundary quadrature (ebq)",level=9)
-        for (k,v) in self.ebq.iteritems(): log(str((k,v.shape)),level=9)
-        log("Global element boundary quadrature (ebq_global)",level=9)
-        for (k,v) in self.ebq_global.iteritems(): log(str((k,v.shape)),level=9)
-        log("Exterior element boundary quadrature (ebqe)",level=9)
-        for (k,v) in self.ebqe.iteritems(): log(str((k,v.shape)),level=9)
-        log("Interpolation points for nonlinear diffusion potential (phi_ip)",level=9)
-        for (k,v) in self.phi_ip.iteritems(): log(str((k,v.shape)),level=9)
+            logEvent(memory("global exterior element boundary quadrature, test/trial functions trial_shape_X_test_shape","OneLevelTransport"),level=4)
+        logEvent("Dumping quadrature shapes for model %s" % self.name,level=9)
+        logEvent("Element quadrature array (q)", level=9)
+        for (k,v) in self.q.iteritems(): logEvent(str((k,v.shape)),level=9)
+        logEvent("Element boundary quadrature (ebq)",level=9)
+        for (k,v) in self.ebq.iteritems(): logEvent(str((k,v.shape)),level=9)
+        logEvent("Global element boundary quadrature (ebq_global)",level=9)
+        for (k,v) in self.ebq_global.iteritems(): logEvent(str((k,v.shape)),level=9)
+        logEvent("Exterior element boundary quadrature (ebqe)",level=9)
+        for (k,v) in self.ebqe.iteritems(): logEvent(str((k,v.shape)),level=9)
+        logEvent("Interpolation points for nonlinear diffusion potential (phi_ip)",level=9)
+        for (k,v) in self.phi_ip.iteritems(): logEvent(str((k,v.shape)),level=9)
         #
         # allocate residual and Jacobian storage
         #
@@ -1331,7 +1329,7 @@ class OneLevelTransport(NonlinearEquation):
                          self.nDOF_test_element[ci],
                          self.nDOF_trial_element[cj]),
                         'd')
-        log(memory("element Jacobian","OneLevelTransport"),level=4)
+        logEvent(memory("element Jacobian","OneLevelTransport"),level=4)
         self.fluxJacobian = {}
         self.fluxJacobian_eb = {}
         self.fluxJacobian_exterior = {}
@@ -1457,7 +1455,7 @@ class OneLevelTransport(NonlinearEquation):
         #
         #
         #
-        log(memory("element and element boundary Jacobians","OneLevelTransport"),level=4)
+        logEvent(memory("element and element boundary Jacobians","OneLevelTransport"),level=4)
         self.inflowBoundaryBC = {}
         self.inflowBoundaryBC_values = {}
         self.inflowFlux = {}
@@ -1483,10 +1481,10 @@ class OneLevelTransport(NonlinearEquation):
         #
         del self.internalNodes
         self.internalNodes = None
-        log("Updating local to global mappings",2)
+        logEvent("Updating local to global mappings",2)
         self.updateLocal2Global()
-        log("Building time integration object",2)
-        log(memory("inflowBC, internalNodes,updateLocal2Global","OneLevelTransport"),level=4)
+        logEvent("Building time integration object",2)
+        logEvent(memory("inflowBC, internalNodes,updateLocal2Global","OneLevelTransport"),level=4)
         #mwf for interpolating subgrid error for gradients etc
         if self.stabilization and self.stabilization.usesGradientStabilization:
             self.timeIntegration = TimeIntegrationClass(self,integrateInterpolationPoints=True)
@@ -1495,8 +1493,8 @@ class OneLevelTransport(NonlinearEquation):
 
         if options != None:
             self.timeIntegration.setFromOptions(options)
-        log(memory("TimeIntegration","OneLevelTransport"),level=4)
-        log("Calculating numerical quadrature formulas",2)
+        logEvent(memory("TimeIntegration","OneLevelTransport"),level=4)
+        logEvent("Calculating numerical quadrature formulas",2)
         self.calculateQuadrature()
 
         comm = Comm.get()
@@ -1513,7 +1511,7 @@ class OneLevelTransport(NonlinearEquation):
             interleave_DOF=False
         self.setupFieldStrides(interleaved=interleave_DOF)
 
-        log(memory("stride+offset","OneLevelTransport"),level=4)
+        logEvent(memory("stride+offset","OneLevelTransport"),level=4)
         if numericalFluxType != None:
             if options == None or options.periodicDirichletConditions == None:
                 self.numericalFlux = numericalFluxType(self,
@@ -1543,12 +1541,12 @@ class OneLevelTransport(NonlinearEquation):
                 ebN = self.mesh.exteriorElementBoundariesArray[ebNE]
                 for k in range(self.nElementBoundaryQuadraturePoints_elementBoundary):
                     self.ebqe['penalty'][ebNE,k] = self.numericalFlux.penalty_constant/self.mesh.elementBoundaryDiametersArray[ebN]**self.numericalFlux.penalty_power
-        log(memory("numericalFlux","OneLevelTransport"),level=4)
+        logEvent(memory("numericalFlux","OneLevelTransport"),level=4)
         self.elementEffectiveDiametersArray  = self.mesh.elementInnerDiametersArray
         #use post processing tools to get conservative fluxes, None by default
         import PostProcessingTools
         self.velocityPostProcessor = PostProcessingTools.VelocityPostProcessingChooser(self)
-        log(memory("velocity postprocessor","OneLevelTransport"),level=4)
+        logEvent(memory("velocity postprocessor","OneLevelTransport"),level=4)
         #helper for writing out data storage
         import Archiver
         self.elementQuadratureDictionaryWriter = Archiver.XdmfWriter()
@@ -1720,10 +1718,10 @@ class OneLevelTransport(NonlinearEquation):
         self.calculateCoefficients()
         self.calculateElementResidual()
         self.scale_dt = False
-        log("Element residual",level=9,data=self.elementResidual)
+        logEvent("Element residual",level=9,data=self.elementResidual)
         if self.timeIntegration.dt < 1.0e-8*self.mesh.h:
             self.scale_dt = True
-            log("Rescaling residual for small time steps")
+            logEvent("Rescaling residual for small time steps")
         else:
             self.scale_dt = False
         for ci in range(self.nc):
@@ -1736,7 +1734,7 @@ class OneLevelTransport(NonlinearEquation):
                                                                   self.l2g[ci]['freeGlobal'],
                                                                   self.elementResidual[ci],
                                                                   r);
-        log("Global residual",level=9,data=r)
+        logEvent("Global residual",level=9,data=r)
         if self.forceStrongConditions:#
             for cj in range(len(self.dirichletConditionsForceDOF)):#
                 for dofN,g in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.iteritems():
@@ -1774,14 +1772,14 @@ class OneLevelTransport(NonlinearEquation):
             for ci in self.fluxJacobian_hj.keys():
                 for cj in self.fluxJacobian_hj[ci].keys():
                     self.fluxJacobian_hj[ci][cj] *= self.timeIntegration.dt
-        log("Element Jacobian ",level=10,data=self.elementJacobian)
+        logEvent("Element Jacobian ",level=10,data=self.elementJacobian)
         if self.matType == superluWrappers.SparseMatrix:
             self.getJacobian_CSR(jacobian)
         elif self.matType  == numpy.array:
             self.getJacobian_dense(jacobian)
         else:
             raise TypeError("Matrix type must be SparseMatrix or array")
-        log("Jacobian ",level=10,data=jacobian)
+        logEvent("Jacobian ",level=10,data=jacobian)
         if self.forceStrongConditions:
             for cj in range(self.nc):
                 for dofN in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.keys():
@@ -3136,7 +3134,7 @@ class OneLevelTransport(NonlinearEquation):
                     if self.stabilization and self.stabilization.trackSubScales:# or self.stabilization.usesGradientStabilization):
                         #mwf this needs to be dmt_sge, but needs to go after calculateSubgridError then
                         #mwf debug
-                        log("Transport adding adjoint mass term dmt_sge(%s,%s) max=%s min=%s " % (ci,cj,cq[('dmt_sge',ci,cj)].max(),cq[('dmt_sge',ci,cj)].min()))
+                        logEvent("Transport adding adjoint mass term dmt_sge(%s,%s) max=%s min=%s " % (ci,cj,cq[('dmt_sge',ci,cj)].max(),cq[('dmt_sge',ci,cj)].min()))
                         cfemIntegrals.updateMass_adjoint(cq[('dmt_sge',ci,cj)],
                                                          cq[('w*dV_stab',ci)],
                                                          cq[('Lstar*w*dV',cj,ci)])
@@ -3187,7 +3185,7 @@ class OneLevelTransport(NonlinearEquation):
 #                                     for I in range(self.nSpace_global):
 #                                         self.q[('df',ci,cj)][eN,k,I]-=self.q[('dm',ci,cj)][eN,k]*self.q['xt'][eN,k,I]
 #                     print "f",ci,self.q[('f',ci)]
-        log("Coefficients on element",level=10,data=self.q)
+        logEvent("Coefficients on element",level=10,data=self.q)
         #
         # let the time integrator calculate m_t and possibly other coefficients at the quadrature points
         #
@@ -3565,11 +3563,11 @@ class OneLevelTransport(NonlinearEquation):
 
 
     def calculateQuadrature(self):
-        log("Element Quadrature",level=3)
+        logEvent("Element Quadrature",level=3)
         self.calculateElementQuadrature()
-        log("Element Boundary Quadrature",level=3)
+        logEvent("Element Boundary Quadrature",level=3)
         self.calculateElementBoundaryQuadrature()
-        log("Global Exterior Element Boundary Quadrature",level=3)
+        logEvent("Global Exterior Element Boundary Quadrature",level=3)
         self.calculateExteriorElementBoundaryQuadrature()
     def updateAfterMeshMotion(self):
         self.calculateQuadrature()#not always the right thing to do (e.g. for optimized models)
@@ -4245,7 +4243,7 @@ class OneLevelTransport(NonlinearEquation):
                                         self.timeIntegration.shockCapturingIsImplicit[ci])
 
         columnIndecesDict={}#replace with C++ map (this  collects column indeces for each row)
-        log("Building sparse matrix structure",level=2)
+        logEvent("Building sparse matrix structure",level=2)
         self.sparsityInfo = cmeshTools.SparsityInfo()
         useC=True
         for ci in range(self.nc):
@@ -4420,24 +4418,24 @@ class OneLevelTransport(NonlinearEquation):
                 memory()
                 self.csrRowIndeces[(ci,cj)] = numpy.zeros((self.mesh.nElements_global,
                                                              self.nDOF_test_element[ci]),'i')
-                log(memory("csrRowIndeces","OneLevelTransport"),level=4)
+                logEvent(memory("csrRowIndeces","OneLevelTransport"),level=4)
                 self.csrColumnOffsets[(ci,cj)] = numpy.zeros((self.mesh.nElements_global,
                                                                 self.nDOF_test_element[ci],self.nDOF_trial_element[cj]),'i')
-                log(memory("csrColumnOffsets","OneLevelTransport"),level=4)
+                logEvent(memory("csrColumnOffsets","OneLevelTransport"),level=4)
                 if hasDiffusionInMixedForm:
                     self.csrColumnOffsets_eNebN[(ci,cj)] = numpy.zeros((self.mesh.nElements_global,self.mesh.nElementBoundaries_element,
                                                                         self.nDOF_test_element[ci],self.nDOF_trial_element[cj]),'i')
                 else:
                     self.csrColumnOffsets_eNebN[(ci,cj)] = numpy.zeros((0,),'i')
-                log(memory("csrColumnOffsets_eNebN","OneLevelTransport"),level=4)
+                logEvent(memory("csrColumnOffsets_eNebN","OneLevelTransport"),level=4)
                 self.csrColumnOffsets_eb[(ci,cj)] = numpy.zeros((self.mesh.nElementBoundaries_global,2,2,self.nDOF_test_element[ci],self.nDOF_trial_element[cj]),'i')
-                log(memory("csrColumnOffsets_eb","OneLevelTransport"),level=4)
+                logEvent(memory("csrColumnOffsets_eb","OneLevelTransport"),level=4)
                 if hasDiffusionInMixedForm:
                     self.csrColumnOffsets_eb_eNebN[(ci,cj)] = numpy.zeros((self.mesh.nElementBoundaries_global,2,2,self.mesh.nElementBoundaries_element,
                                                                            self.nDOF_test_element[ci],self.nDOF_trial_element[cj]),'i')
                 else:
                     self.csrColumnOffsets_eb_eNebN[(ci,cj)] = numpy.zeros((0,),'i')
-                log(memory("csrColumnOffsets_eb_eNebN","OneLevelTransport"),level=4)
+                logEvent(memory("csrColumnOffsets_eb_eNebN","OneLevelTransport"),level=4)
                 if useC:
                     self.sparsityInfo.setOffsets_CSR(self.mesh.nElements_global,
                                                      self.nDOF_test_element[ci],
@@ -5604,7 +5602,7 @@ class OneLevelTransport(NonlinearEquation):
         #
         for key in q_save.keys():
             self.q[key].flat[:] = q_save[key].flat[:]
-        log("Coefficients on element",level=10,data=self.q)
+        logEvent("Coefficients on element",level=10,data=self.q)
         ## exterior element boundaries
     def calculateElementLoad_inhomogeneous(self):
         """
@@ -5809,7 +5807,7 @@ class OneLevelTransport(NonlinearEquation):
                                                                   self.l2g[ci]['freeGlobal'],
                                                                   self.elementResidual[ci],
                                                                   f);
-        log("Global Load Vector",level=9,data=f)
+        logEvent("Global Load Vector",level=9,data=f)
 
 
     def getMassJacobian(self,jacobian):
@@ -5819,7 +5817,7 @@ class OneLevelTransport(NonlinearEquation):
         import superluWrappers
         import numpy
         self.calculateElementMassJacobian()
-        log("Element Mass Jacobian ",level=10,data=self.elementJacobian)
+        logEvent("Element Mass Jacobian ",level=10,data=self.elementJacobian)
         if self.matType == superluWrappers.SparseMatrix:
             cfemIntegrals.zeroJacobian_CSR(self.nNonzerosInJacobian,
                                            jacobian)
@@ -5860,7 +5858,7 @@ class OneLevelTransport(NonlinearEquation):
 
         else:
             raise TypeError("Matrix type must be SparseMatrix or array")
-        log("Mass Jacobian ",level=10,data=jacobian)
+        logEvent("Mass Jacobian ",level=10,data=jacobian)
         if self.forceStrongConditions:
             for cj in range(self.nc):
                 for dofN in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.keys():
@@ -5895,10 +5893,10 @@ class OneLevelTransport(NonlinearEquation):
         self.calculateCoefficients()
         self.calculateElementResidual()
         self.scale_dt = False
-        log("Element spatial residual",level=9,data=self.elementSpatialResidual)
+        logEvent("Element spatial residual",level=9,data=self.elementSpatialResidual)
         if self.timeIntegration.dt < 1.0e-8*self.mesh.h:
             self.scale_dt = True
-            log("Rescaling residual for small time steps")
+            logEvent("Rescaling residual for small time steps")
         else:
             self.scale_dt = False
         for ci in range(self.nc):
@@ -5911,7 +5909,7 @@ class OneLevelTransport(NonlinearEquation):
                                                                   self.l2g[ci]['freeGlobal'],
                                                                   self.elementSpatialResidual[ci],
                                                                   r);
-        log("Global spatial residual",level=9,data=r)
+        logEvent("Global spatial residual",level=9,data=r)
         if self.forceStrongConditions:#
             for cj in range(len(self.dirichletConditionsForceDOF)):#
                 for dofN,g in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.iteritems():
@@ -5941,10 +5939,10 @@ class OneLevelTransport(NonlinearEquation):
             elementMassResidual[ci]-= self.elementSpatialResidual[ci]
 
         self.scale_dt = False
-        log("Element Mass residual",level=9,data=elementMassResidual)
+        logEvent("Element Mass residual",level=9,data=elementMassResidual)
         if self.timeIntegration.dt < 1.0e-8*self.mesh.h:
             self.scale_dt = True
-            log("Rescaling residual for small time steps")
+            logEvent("Rescaling residual for small time steps")
         else:
             self.scale_dt = False
         for ci in range(self.nc):
@@ -5957,7 +5955,7 @@ class OneLevelTransport(NonlinearEquation):
                                                                   self.l2g[ci]['freeGlobal'],
                                                                   elementMassResidual[ci],
                                                                   r);
-        log("Global mass residual",level=9,data=r)
+        logEvent("Global mass residual",level=9,data=r)
         if self.forceStrongConditions:#
             for cj in range(len(self.dirichletConditionsForceDOF)):#
                 for dofN,g in self.dirichletConditionsForceDOF[cj].DOFBoundaryConditionsDict.iteritems():
@@ -6066,7 +6064,7 @@ class MultilevelTransport:
         self.phiSpaceDictList = []
         #self.phiSpaceListDict = {}
 
-        log("Building Transport for each mesh",level=2)
+        logEvent("Building Transport for each mesh",level=2)
         for  cj in TrialSpaceTypeDict.keys():
             self.trialSpaceListDict[cj]=[]
             self.bcListDict[cj]=[]
@@ -6075,32 +6073,32 @@ class MultilevelTransport:
        #     pdb.set_trace()
             sdmesh = mesh.subdomainMesh
             memory()
-            log("Generating Trial Space",level=2)
+            logEvent("Generating Trial Space",level=2)
             trialSpaceDict = dict([ (cj,TrialSpaceType(sdmesh,nd)) for (cj,TrialSpaceType) in TrialSpaceTypeDict.iteritems()])
             self.trialSpaceDictList.append(trialSpaceDict)
-            log("Generating Test Space",level=2)
+            logEvent("Generating Test Space",level=2)
             testSpaceDict = dict([(ci,TestSpaceType(sdmesh,nd)) for (ci,TestSpaceType) in TestSpaceTypeDict.iteritems()])
             self.testSpaceDictList.append(testSpaceDict)
-            log("Allocating u",level=2)
+            logEvent("Allocating u",level=2)
             uDict = dict([(cj,FiniteElementFunction(trialSpace,name=coefficients.variableNames[cj])) for (cj,trialSpace) in trialSpaceDict.iteritems()])
             #11/11/09 allow FiniteElementFunction to communicate uknowns across procs
             for cj in uDict.keys():
                 uDict[cj].setupParallelCommunication()
             self.uDictList.append(uDict)
-            log("Allocating phi")
+            logEvent("Allocating phi")
             phiSpaceDict = dict([ (cj,PhiSpaceType(sdmesh,nd)) for (cj,PhiSpaceType) in PhiSpaceTypeDict.iteritems()])
             self.phiSpaceDictList.append(phiSpaceDict)
             phiDict = dict([(cj,FiniteElementFunction(phiSpace)) for (cj,phiSpace) in phiSpaceDict.iteritems()])
             #need to communicate phi if nonlinear potential and there is spatial dependence in potential function
             for cj in phiDict.keys():
                 phiDict[cj].setupParallelCommunication()
-            log(memory("finite element spaces","MultilevelTransport"),level=4)
-            log("Setting Boundary Conditions")
+            logEvent(memory("finite element spaces","MultilevelTransport"),level=4)
+            logEvent("Setting Boundary Conditions")
             if numericalFluxType==None:
                 useWeakDirichletConditions=False
             else:
                 useWeakDirichletConditions=numericalFluxType.useWeakDirichletConditions
-            log("Setting Boundary Conditions-1")
+            logEvent("Setting Boundary Conditions-1")
             import pdb
 #            pdb.set_trace()
             for cj in trialSpaceDict.keys():
@@ -6108,20 +6106,20 @@ class MultilevelTransport:
                     dirichletConditionsSetterDict[cj] = None
                 if not fluxBoundaryConditionsDict.has_key(cj):
                     fluxBoundaryConditionsDict[cj] = None
-            log("Setting Boundary Conditions-2")
+            logEvent("Setting Boundary Conditions-2")
             if options == None or options.periodicDirichletConditions == None or options.parallelPeriodic==True:
-                log("Setting Boundary Conditions-2a")
+                logEvent("Setting Boundary Conditions-2a")
                 dirichletConditionsDict=dict([(cj,DOFBoundaryConditions(
                     trialSpace,dirichletConditionsSetterDict[cj],useWeakDirichletConditions))
                                               for (cj,trialSpace) in trialSpaceDict.iteritems()])
             else:
-                log("Setting Boundary Conditions-2b")
+                logEvent("Setting Boundary Conditions-2b")
                 dirichletConditionsDict=dict([(cj,DOFBoundaryConditions(
                     trialSpace,dirichletConditionsSetterDict[cj],useWeakDirichletConditions,options.periodicDirichletConditions[cj]))
                                               for (cj,trialSpace) in trialSpaceDict.iteritems()])
-            log("Setting Boundary Conditions-3")
+            logEvent("Setting Boundary Conditions-3")
             self.bcDictList.append(dirichletConditionsDict)
-            log("Setting Boundary Conditions-4")
+            logEvent("Setting Boundary Conditions-4")
             for cj in TrialSpaceTypeDict.keys():
                 self.trialSpaceListDict[cj].append(trialSpaceDict[cj])
                 self.bcListDict[cj].append(dirichletConditionsDict[cj])
@@ -6130,10 +6128,10 @@ class MultilevelTransport:
             import Comm
             comm = Comm.get()
             if options.periodicDirichletConditions and options.parallelPeriodic:
-                log("Generating Trial Space--Parallel Periodic",level=2)
+                logEvent("Generating Trial Space--Parallel Periodic",level=2)
                 #the global mesh has been renumbered so all this is in the new (partitioned) numberings
                 trialSpace_global = TrialSpaceType(mesh,nd)
-                log("Setting Boundary Conditions--Parallel Periodic")
+                logEvent("Setting Boundary Conditions--Parallel Periodic")
                 #get new global numbering of DOF that maps periodic DOF to a single master DOF
                 periodicConditions_global=DOFBoundaryConditions(trialSpace_global,
                                                                 lambda x,flag: None,
@@ -6203,8 +6201,8 @@ class MultilevelTransport:
                     testSpaceDict[ci].dofMap.nDOF_subdomain_owned = trialSpaceDict[0].dofMap.nDOF_subdomain_owned
             #
             #
-            log(memory("boundary conditions","MultilevelTransport"),level=4)
-            log("Initializing OneLevelTransport",level=2)
+            logEvent(memory("boundary conditions","MultilevelTransport"),level=4)
+            logEvent("Initializing OneLevelTransport",level=2)
             transport=self.OneLevelTransportType(uDict,
                                             phiDict,
                                             testSpaceDict,
@@ -6233,18 +6231,18 @@ class MultilevelTransport:
             self.strideListList.append(transport.stride)
             memory()
             self.levelModelList.append(transport)
-            log("Allocating residual and solution vectors",level=2)
+            logEvent("Allocating residual and solution vectors",level=2)
             u = numpy.zeros((transport.dim,),'d')
             du = numpy.zeros((transport.dim,),'d')
             r = numpy.zeros((transport.dim,),'d')
             self.uList.append(u)
             self.duList.append(du)
             self.rList.append(r)
-            log("Allocating Jacobian",level=2)
+            logEvent("Allocating Jacobian",level=2)
             jacobian = transport.initializeJacobian()
             self.jacobianList.append(jacobian)
             par_bs = transport.coefficients.nc
-            log("Allocating parallel storage",level=2)
+            logEvent("Allocating parallel storage",level=2)
             comm = Comm.get()
             self.comm=comm
             if (comm.size() > 1):
@@ -6461,23 +6459,23 @@ class MultilevelTransport:
                         transport.owned_local = numpy.arange(par_n*par_bs)
                         par_nghost = trialSpaceDict[0].dofMap.nDOF_subdomain - par_n
                         subdomain2global = trialSpaceDict[0].dofMap.subdomain2global
-                        log("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                        logEvent("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                         par_u = ParVec_petsc4py(u,par_bs,par_n,par_N,par_nghost,subdomain2global)
                         par_r = ParVec_petsc4py(r,par_bs,par_n,par_N,par_nghost,subdomain2global)
-                        log("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                        logEvent("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                         par_du = ParVec_petsc4py(du,par_bs,par_n,par_N)
-                        log("Allocating matrix on rank %i" % comm.rank(),level=2)
+                        logEvent("Allocating matrix on rank %i" % comm.rank(),level=2)
                         par_jacobian = ParMat_petsc4py(jacobian,par_bs,par_n,par_N,par_nghost,subdomain2global,pde=transport)
                 else:
                     par_nghost = trialSpaceDict[0].dofMap.nDOF_subdomain - par_n
                     subdomain2global = trialSpaceDict[0].dofMap.subdomain2global
                     max_dof_neighbors= trialSpaceDict[0].dofMap.max_dof_neighbors
-                    log("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                     par_u = ParVec(u,par_bs,par_n,par_N,par_nghost,subdomain2global)
                     par_r = ParVec(r,par_bs,par_n,par_N,par_nghost,subdomain2global)
-                    log("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                     par_du = ParVec(du,par_bs,par_n,par_N)
-                    log("Allocating matrix on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating matrix on rank %i" % comm.rank(),level=2)
                     par_jacobian = flcbdfWrappers.ParMat(par_bs,par_n,par_N,par_nghost,max_dof_neighbors,subdomain2global,jacobian)
             elif  (options.multilevelLinearSolver == PETSc or
                    options.levelLinearSolver == PETSc):
@@ -6487,12 +6485,12 @@ class MultilevelTransport:
                 par_nghost = 0
                 subdomain2global = trialSpaceDict[0].dofMap.subdomain2global
                 max_dof_neighbors= trialSpaceDict[0].dofMap.max_dof_neighbors
-                log("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                logEvent("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                 par_u = ParVec(u,par_bs,par_n,par_N,par_nghost,subdomain2global[:par_n])
                 par_r = ParVec(r,par_bs,par_n,par_N,par_nghost,subdomain2global[:par_n])
-                log("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                logEvent("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                 par_du = ParVec(du,par_bs,par_n,par_N)
-                log("Allocating matrix on rank %i" % comm.rank(),level=2)
+                logEvent("Allocating matrix on rank %i" % comm.rank(),level=2)
                 par_jacobian = flcbdfWrappers.ParMat(par_bs,par_n,par_N,par_nghost,max_dof_neighbors,subdomain2global[:par_n],jacobian)
             elif  (options.multilevelLinearSolver == KSP_petsc4py or
                    options.levelLinearSolver == KSP_petsc4py):
@@ -6504,7 +6502,7 @@ class MultilevelTransport:
                     if ts.dofMap.nDOF_all_processes != par_N:
                         mixed=True
                 par_nghost = 0
-                log("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                logEvent("Allocating ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                 if mixed:
                     par_N = par_n = sum([ts.dofMap.nDOF_all_processes for ts in trialSpaceDict.values()])
                     transport.owned_local = numpy.arange(par_n)
@@ -6512,9 +6510,9 @@ class MultilevelTransport:
                                                      offset,ts in zip(transport.offset,trialSpaceDict.values())])
                     par_u = ParVec_petsc4py(u,1,par_n,par_N,par_nghost,subdomain2global[:par_n])
                     par_r = ParVec_petsc4py(r,1,par_n,par_N,par_nghost,subdomain2global[:par_n])
-                    log("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                     par_du = ParVec_petsc4py(du,1,par_n,par_N)
-                    log("Allocating matrix on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating matrix on rank %i" % comm.rank(),level=2)
                     par_jacobian = ParMat_petsc4py(jacobian,1,par_n,par_N,par_nghost,subdomain2global,pde=transport)
                 else:
                     transport.owned_local = numpy.arange(par_n*par_bs)
@@ -6522,9 +6520,9 @@ class MultilevelTransport:
                     max_dof_neighbors= trialSpaceDict[0].dofMap.max_dof_neighbors
                     par_u = ParVec_petsc4py(u,par_bs,par_n,par_N,par_nghost,subdomain2global[:par_n])
                     par_r = ParVec_petsc4py(r,par_bs,par_n,par_N,par_nghost,subdomain2global[:par_n])
-                    log("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating un-ghosted parallel vectors on rank %i" % comm.rank(),level=2)
                     par_du = ParVec_petsc4py(du,par_bs,par_n,par_N)
-                    log("Allocating matrix on rank %i" % comm.rank(),level=2)
+                    logEvent("Allocating matrix on rank %i" % comm.rank(),level=2)
                     par_jacobian = ParMat_petsc4py(jacobian,par_bs,par_n,par_N,par_nghost,subdomain2global,pde=transport)
             else:
                 transport.owned_local = numpy.arange(transport.dim)
@@ -6536,8 +6534,8 @@ class MultilevelTransport:
             self.par_duList.append(par_du)
             self.par_rList.append(par_r)
             self.par_jacobianList.append(par_jacobian)
-            log(memory("global Jacobian and vectors","MultilevelTransport"),level=4)
-        log("Building Mesh Transfers",level=2)
+            logEvent(memory("global Jacobian and vectors","MultilevelTransport"),level=4)
+        logEvent("Building Mesh Transfers",level=2)
         MultilevelProjectionOperatorType = MultilevelProjectionOperators
         self. meshTransfers = MultilevelProjectionOperatorType(
             mlMesh,
@@ -6545,11 +6543,11 @@ class MultilevelTransport:
             self.offsetListList,
             self.strideListList,
             self.bcDictList)
-        log(memory("mesh transfers","MultilevelTransport"),level=4)
+        logEvent(memory("mesh transfers","MultilevelTransport"),level=4)
         #mwf hack keep reference to mlMesh in Transport ctor for now
         self.mlMeshSave = mlMesh
     def setInitialConditions(self,getInitialConditionsDict,T=0.0):
-        log("Setting initial conditions on model "+self.name)
+        logEvent("Setting initial conditions on model "+self.name)
         self.t=T
         for m,u in zip(self.levelModelList,self.uList):
             m.setInitialConditions(getInitialConditionsDict,T)
@@ -6578,11 +6576,11 @@ class MultilevelTransport:
         for idx, par_jacobian in enumerate(self.par_jacobianList):
             if hasattr(par_jacobian, 'save'):
                 filename = file_prefix + 'par_j' + '_' + str(idx)
-                log('Saving Parallel Jacobian to %s' % filename)
+                logEvent('Saving Parallel Jacobian to %s' % filename)
                 par_jacobian.save(filename)
         if b and hasattr(b, 'save'):
             filename = file_prefix + 'b'
-            log('Saving right-hand-side to %s' % filename)
+            logEvent('Saving right-hand-side to %s' % filename)
             b.save(filename)
 
 ## @}

--- a/proteus/TransportCoefficients.py
+++ b/proteus/TransportCoefficients.py
@@ -10,15 +10,11 @@ this module define common PDE's.
 from math import *
 import numpy
 import Norms
-import Profiling
-
-log = Profiling.logEvent
+from Profiling import logEvent
 
 ## \file TransportCoefficients.py
 #
 #@{
-
-log = Profiling.logEvent
 
 ##\brief Base class for transport coefficients classes
 #
@@ -3616,7 +3612,7 @@ class NCLevelSetCoefficients(TC_base):
                                                                      self.model.q['dV'],
                                                                      self.model.q[('u',0)],
                                                                      self.model.mesh.nElements_owned)
-            log("Attach Models NCLS: Phase  0 mass before NCLS step = %12.5e" % (self.m_pre,),level=2)
+            logEvent("Attach Models NCLS: Phase  0 mass before NCLS step = %12.5e" % (self.m_pre,),level=2)
             self.totalFluxGlobal=0.0
             self.lsGlobalMassArray = [self.m_pre]
             self.lsGlobalMassErrorArray = [0.0]
@@ -3639,14 +3635,14 @@ class NCLevelSetCoefficients(TC_base):
                                                                      self.model.q['dV'],
                                                                      self.model.q[('u',0)],
                                                                      self.model.mesh.nElements_owned)
-            log("Phase  0 mass before NCLS step = %12.5e" % (self.m_pre,),level=2)
+            logEvent("Phase  0 mass before NCLS step = %12.5e" % (self.m_pre,),level=2)
             self.m_last = self.m_pre
             # self.m_last = Norms.scalarSmoothedHeavisideDomainIntegral(self.epsFact,
             #                                                           self.model.mesh.elementDiametersArray,
             #                                                           self.model.q['dV'],
             #                                                           self.model.timeIntegration.m_last[0],
             #                                                           self.model.mesh.nElements_owned)
-            # log("Phase  0 mass before NCLS step (m_last) = %12.5e" % (self.m_last,),level=2)
+            # logEvent("Phase  0 mass before NCLS step (m_last) = %12.5e" % (self.m_last,),level=2)
         #cek todo why is this here
         if self.flowModelIndex >= 0 and self.flowModel.ebq.has_key(('v',1)):
             self.model.u[0].getValuesTrace(self.flowModel.ebq[('v',1)],self.model.ebq[('u',0)])
@@ -3660,14 +3656,14 @@ class NCLevelSetCoefficients(TC_base):
                                                                       self.model.q['dV'],
                                                                       self.model.q[('u',0)],
                                                                       self.model.mesh.nElements_owned)
-            log("Phase  0 mass after NCLS step = %12.5e" % (self.m_post,),level=2)
+            logEvent("Phase  0 mass after NCLS step = %12.5e" % (self.m_post,),level=2)
             #need a flux here not a velocity
             self.fluxIntegral = Norms.fluxDomainBoundaryIntegralFromVector(self.ebqe_dS,
                                                                            self.ebqe_v,
                                                                            self.model.ebqe['n'],
                                                                            self.model.mesh)
-            log("Flux integral = %12.5e" % (self.fluxIntegral,),level=2)
-            log("Phase  0 mass conservation after NCLS step = %12.5e" % (self.m_post - self.m_last + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
+            logEvent("Flux integral = %12.5e" % (self.fluxIntegral,),level=2)
+            logEvent("Phase  0 mass conservation after NCLS step = %12.5e" % (self.m_post - self.m_last + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
             self.lsGlobalMass = self.m_post
             self.fluxGlobal = self.fluxIntegral*self.model.timeIntegration.dt
             self.totalFluxGlobal += self.fluxGlobal
@@ -3928,16 +3924,16 @@ class VOFCoefficients(TC_base):
             self.m_pre = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                      self.model.q[('m',0)],
                                                      self.model.mesh.nElements_owned)
-            log("Attach Models VOF: Phase  0 mass after VOF step = %12.5e" % (self.m_pre,),level=2)
+            logEvent("Attach Models VOF: Phase  0 mass after VOF step = %12.5e" % (self.m_pre,),level=2)
             self.m_post = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                      self.model.q[('m',0)],
                                                      self.model.mesh.nElements_owned)
-            log("Attach Models VOF: Phase  0 mass after VOF step = %12.5e" % (self.m_post,),level=2)
+            logEvent("Attach Models VOF: Phase  0 mass after VOF step = %12.5e" % (self.m_post,),level=2)
             if self.model.ebqe.has_key(('advectiveFlux',0)):
                 self.fluxIntegral = Norms.fluxDomainBoundaryIntegral(self.model.ebqe['dS'],
                                                                      self.model.ebqe[('advectiveFlux',0)],
                                                                      self.model.mesh)
-                log("Attach Models VOF: Phase  0 mass conservation after VOF step = %12.5e" % (self.m_post - self.m_pre + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
+                logEvent("Attach Models VOF: Phase  0 mass conservation after VOF step = %12.5e" % (self.m_post - self.m_pre + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
 
     def initializeElementQuadrature(self,t,cq):
         if self.flowModelIndex == None:
@@ -3959,11 +3955,11 @@ class VOFCoefficients(TC_base):
             self.m_pre = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                     self.model.q[('m',0)],
                                                     self.model.mesh.nElements_owned)
-            log("Phase  0 mass before VOF step = %12.5e" % (self.m_pre,),level=2)
+            logEvent("Phase  0 mass before VOF step = %12.5e" % (self.m_pre,),level=2)
             self.m_last = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                      self.model.timeIntegration.m_last[0],
                                                      self.model.mesh.nElements_owned)
-            log("Phase  0 mass before VOF (m_last) step = %12.5e" % (self.m_last,),level=2)
+            logEvent("Phase  0 mass before VOF (m_last) step = %12.5e" % (self.m_last,),level=2)
         copyInstructions = {}
         return copyInstructions
     def postStep(self,t,firstStep=False):
@@ -3971,17 +3967,17 @@ class VOFCoefficients(TC_base):
             self.m_post = Norms.scalarDomainIntegral(self.model.q['dV'],
                                                      self.model.q[('m',0)],
                                                      self.model.mesh.nElements_owned)
-            log("Phase  0 mass after VOF step = %12.5e" % (self.m_post,),level=2)
+            logEvent("Phase  0 mass after VOF step = %12.5e" % (self.m_post,),level=2)
             self.fluxIntegral = Norms.fluxDomainBoundaryIntegral(self.model.ebqe['dS'],
                                                                  self.model.ebqe[('advectiveFlux',0)],
                                                                  self.model.mesh)
-            log("Phase  0 mass flux boundary integral after VOF step = %12.5e" % (self.fluxIntegral,),level=2)
-            log("Phase  0 mass conservation after VOF step = %12.5e" % (self.m_post - self.m_last + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
+            logEvent("Phase  0 mass flux boundary integral after VOF step = %12.5e" % (self.fluxIntegral,),level=2)
+            logEvent("Phase  0 mass conservation after VOF step = %12.5e" % (self.m_post - self.m_last + self.model.timeIntegration.dt*self.fluxIntegral,),level=2)
             divergence = Norms.fluxDomainBoundaryIntegralFromVector(self.model.ebqe['dS'],
                                                                     self.ebqe_v,
                                                                     self.model.ebqe['n'],
                                                                     self.model.mesh)
-            log("Divergence = %12.5e" % (divergence,),level=2)
+            logEvent("Divergence = %12.5e" % (divergence,),level=2)
         copyInstructions = {}
         return copyInstructions
     def updateToMovingDomain(self,t,c):
@@ -4012,7 +4008,7 @@ class VOFCoefficients(TC_base):
                                          c[('f',0)],
                                          c[('df',0,0)])
         if self.checkMass:
-            log("Phase  0 mass in eavl = %12.5e" % (Norms.scalarDomainIntegral(self.model.q['dV'],
+            logEvent("Phase  0 mass in eavl = %12.5e" % (Norms.scalarDomainIntegral(self.model.q['dV'],
                                                                                self.model.q[('m',0)],
                                                                                self.model.mesh.nElements_owned),),level=2)
 
@@ -4124,7 +4120,7 @@ class LevelSetCurvatureCoefficients(TC_base):
     def initializeMesh(self,mesh):
         self.eps = self.epsFact*mesh.h
     def attachModels(self,modelList):
-        log("Attaching \grad \phi in curvature model")
+        logEvent("Attaching \grad \phi in curvature model")
         self.q_grad_phi    = modelList[self.levelSetModelIndex].q[('grad(u)',0)]
         self.ebqe_grad_phi = modelList[self.levelSetModelIndex].ebqe[('grad(u)',0)]
         if modelList[self.levelSetModelIndex].ebq.has_key(('grad(u)',0)):
@@ -4236,7 +4232,7 @@ class LevelSetConservation(TC_base):
         self.epsDiffusion = self.epsFactDiffusion*mesh.h
     def attachModels(self,modelList):
         import copy
-        log("Attaching models in LevelSetConservation")
+        logEvent("Attaching models in LevelSetConservation")
         #level set
         self.lsModel = modelList[self.levelSetModelIndex]
         self.q_u_ls    = modelList[self.levelSetModelIndex].q[('u',0)]
@@ -4264,7 +4260,7 @@ class LevelSetConservation(TC_base):
                 self.lsGlobalMass = Norms.scalarHeavisideDomainIntegral(self.vofModel.q['dV'],
                                                                         self.lsModel.q[('u',0)],
                                                                         self.massCorrModel.mesh.nElements_owned)
-                log("Attach Models MCorr: mass correction %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
+                logEvent("Attach Models MCorr: mass correction %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
                                                                                                 self.massCorrModel.q[('r',0)],
                                                                                                 self.massCorrModel.mesh.nElements_owned),),level=2)
                 self.fluxGlobal = 0.0
@@ -4275,10 +4271,10 @@ class LevelSetConservation(TC_base):
                 self.lsGlobalMassErrorArray = [self.lsGlobalMass - self.lsGlobalMassArray[0] + self.vofModel.timeIntegration.dt*self.vofModel.coefficients.fluxIntegral]
                 self.fluxArray = [self.vofModel.coefficients.fluxIntegral]
                 self.timeArray = [self.vofModel.timeIntegration.t]
-                log("Attach Models MCorr: Phase 0 mass after mass correction (VOF) %12.5e" % (self.vofGlobalMass,),level=2)
-                log("Attach Models MCorr: Phase 0 mass after mass correction (LS) %12.5e" % (self.lsGlobalMass,),level=2)
-                log("Attach Models MCorr: Phase  0 mass conservation (VOF) after step = %12.5e" % (self.vofGlobalMass - self.vofModel.coefficients.m_pre + self.vofModel.timeIntegration.dt*self.vofModel.coefficients.fluxIntegral,),level=2)
-                log("Attach Models MCorr: Phase  0 mass conservation (LS) after step = %12.5e" % (self.lsGlobalMass - self.lsModel.coefficients.m_pre + self.vofModel.timeIntegration.dt*self.vofModel.coefficients.fluxIntegral,),level=2)
+                logEvent("Attach Models MCorr: Phase 0 mass after mass correction (VOF) %12.5e" % (self.vofGlobalMass,),level=2)
+                logEvent("Attach Models MCorr: Phase 0 mass after mass correction (LS) %12.5e" % (self.lsGlobalMass,),level=2)
+                logEvent("Attach Models MCorr: Phase  0 mass conservation (VOF) after step = %12.5e" % (self.vofGlobalMass - self.vofModel.coefficients.m_pre + self.vofModel.timeIntegration.dt*self.vofModel.coefficients.fluxIntegral,),level=2)
+                logEvent("Attach Models MCorr: Phase  0 mass conservation (LS) after step = %12.5e" % (self.lsGlobalMass - self.lsModel.coefficients.m_pre + self.vofModel.timeIntegration.dt*self.vofModel.coefficients.fluxIntegral,),level=2)
     def initializeElementQuadrature(self,t,cq):
         if self.sd and cq.has_key(('a',0,0)):
             cq[('a',0,0)].fill(self.epsDiffusion)
@@ -4290,10 +4286,10 @@ class LevelSetConservation(TC_base):
             cebqe[('a',0,0)].fill(self.epsDiffusion)
     def preStep(self,t,firstStep=False):
         if self.checkMass:
-            log("Phase 0 mass before mass correction (VOF) %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
+            logEvent("Phase 0 mass before mass correction (VOF) %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
                                                                                                  self.vofModel.q[('m',0)],
                                                                                                  self.massCorrModel.mesh.nElements_owned),),level=2)
-            log("Phase 0 mass before mass correction (LS) %12.5e" % (Norms.scalarHeavisideDomainIntegral(self.vofModel.q['dV'],
+            logEvent("Phase 0 mass before mass correction (LS) %12.5e" % (Norms.scalarHeavisideDomainIntegral(self.vofModel.q['dV'],
                                                                                                          self.lsModel.q[('m',0)],
                                                                                                          self.massCorrModel.mesh.nElements_owned),),level=2)
         copyInstructions = {'clear_uList':True}
@@ -4322,7 +4318,7 @@ class LevelSetConservation(TC_base):
                 self.lsGlobalMass = Norms.scalarHeavisideDomainIntegral(self.vofModel.q['dV'],
                                                                         self.lsModel.q[('u',0)],
                                                                         self.massCorrModel.mesh.nElements_owned)
-                log("mass correction %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
+                logEvent("mass correction %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
                                                                            self.massCorrModel.q[('r',0)],
                                                                            self.massCorrModel.mesh.nElements_owned),),level=2)
                 self.fluxGlobal = self.vofModel.coefficients.fluxIntegral*self.vofModel.timeIntegration.dt
@@ -4333,10 +4329,10 @@ class LevelSetConservation(TC_base):
                 self.lsGlobalMassErrorArray.append(self.lsGlobalMass - self.lsGlobalMassArray[0] + self.totalFluxGlobal)
                 self.fluxArray.append(self.vofModel.coefficients.fluxIntegral)
                 self.timeArray.append(self.vofModel.timeIntegration.t)
-                log("Phase 0 mass after mass correction (VOF) %12.5e" % (self.vofGlobalMass,),level=2)
-                log("Phase 0 mass after mass correction (LS) %12.5e" % (self.lsGlobalMass,),level=2)
-                log("Phase  0 mass conservation (VOF) after step = %12.5e" % (self.vofGlobalMass - self.vofModel.coefficients.m_last + self.fluxGlobal,),level=2)
-                log("Phase  0 mass conservation (LS) after step = %12.5e" % (self.lsGlobalMass - self.lsModel.coefficients.m_last + self.fluxGlobal,),level=2)
+                logEvent("Phase 0 mass after mass correction (VOF) %12.5e" % (self.vofGlobalMass,),level=2)
+                logEvent("Phase 0 mass after mass correction (LS) %12.5e" % (self.lsGlobalMass,),level=2)
+                logEvent("Phase  0 mass conservation (VOF) after step = %12.5e" % (self.vofGlobalMass - self.vofModel.coefficients.m_last + self.fluxGlobal,),level=2)
+                logEvent("Phase  0 mass conservation (LS) after step = %12.5e" % (self.lsGlobalMass - self.lsModel.coefficients.m_last + self.fluxGlobal,),level=2)
         copyInstructions = {}
         return copyInstructions
     def evaluate(self,t,c):
@@ -4377,10 +4373,10 @@ class LevelSetConservation(TC_base):
         if (self.checkMass and c[('u',0)].shape == self.q_u_ls.shape):
             self.m_tmp[:] = H_vof
             self.m_tmp += self.massCorrModel.q[('r',0)]
-            log("mass correction during Newton %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
+            logEvent("mass correction during Newton %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
                                                                                      self.massCorrModel.q[('r',0)],
                                                                                      self.massCorrModel.mesh.nElements_owned),),level=2)
-            log("Phase 0 mass during Newton %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
+            logEvent("Phase 0 mass during Newton %12.5e" % (Norms.scalarDomainIntegral(self.vofModel.q['dV'],
                                                                                  self.m_tmp,
                                                                                   self.massCorrModel.mesh.nElements_owned),),level=2)
 
@@ -5891,7 +5887,7 @@ class RedistanceLevelSet(TC_base):
         import pdb
         #pdb.set_trace()
         if self.nModel != None:
-            log("resetting signed distance level set to current level set",level=2)
+            logEvent("resetting signed distance level set to current level set",level=2)
             self.rdModel.u[0].dof[:] = self.nModel.u[0].dof[:]
             self.rdModel.calculateCoefficients()
             self.rdModel.calculateElementResidual()
@@ -5914,7 +5910,7 @@ class RedistanceLevelSet(TC_base):
     def postStep(self,t,firstStep=False):
         if self.nModel != None:
             if self.applyRedistancing == True:
-                log("resetting level set to signed distance")
+                logEvent("resetting level set to signed distance")
                 self.nModel.u[0].dof.flat[:]  = self.rdModel.u[0].dof.flat[:]
                 self.nModel.calculateCoefficients()
                 self.nModel.calculateElementResidual()

--- a/proteus/TwophaseDarcyCoefficients.py
+++ b/proteus/TwophaseDarcyCoefficients.py
@@ -7,8 +7,7 @@ An extension of the TransportCoefficients module for two-phase flow in porous me
 from math import *
 from TransportCoefficients import TC_base
 import numpy
-import Profiling
-log = Profiling.logEvent
+from Profiling import logEvent
 
 #base class for setting up fluid and material properties
 class TwophaseDarcyFlow_base(TC_base):

--- a/proteus/testStuff.py
+++ b/proteus/testStuff.py
@@ -10,7 +10,7 @@ import FemTools
 #for timing
 import sys,os,copy,timeit
 import Profiling
-log = Profiling.logEvent
+from .Profiling import logEvent
 TESTVPPTIMES = False
 
 #######################################################################
@@ -1552,7 +1552,7 @@ class SSPRKNewton(NonlinearSolvers.Newton):
                                                                         self.atol_r,
                                                                         self.rtol_r)
                 if ls_its > 0:
-                    log("Linesearches = %i" % ls_its,level=3)
+                    logEvent("Linesearches = %i" % ls_its,level=3)
         else:
             if self.linearSolver.computeEigenvalues:
                 if self.betaK_0*self.etaK_0*self.gammaK_max <= 0.5:


### PR DESCRIPTION
log and logEvent are used interchangeably throughout the library.  Since `log` is ambiguous, this PR seeks to standardize all logEvents in the library.  Note, this is meant to address #401. 