### PR TITLE
Moved import statements from inside function to top of module.

### DIFF
--- a/proteus/Transport.py
+++ b/proteus/Transport.py
@@ -27,6 +27,9 @@ import Comm
 import flcbdfWrappers
 import cmeshTools
 from .Profiling import logEvent
+import superluWrappers
+import numpy
+
 
 class StorageSet(set):
     def __init__(self,initializer=[],shape=(0,),storageType='d'):
@@ -1747,8 +1750,6 @@ class OneLevelTransport(NonlinearEquation):
         #imax = numpy.argmax(r); imin = numpy.argmin(r)
         #print "getResidual max,index r[%s]= %s min,index= r[%s] r= %s " % (imax,r[imax],imin,r[imin])
     def getJacobian(self,jacobian,skipMassTerms=False):
-        import superluWrappers
-        import numpy
         ##\todo clean up update,calculate,get,intialize usage
         self.calculateElementBoundaryJacobian()
         self.calculateExteriorElementBoundaryJacobian()

--- a/proteus/Transport.py
+++ b/proteus/Transport.py
@@ -30,7 +30,6 @@ from .Profiling import logEvent
 import superluWrappers
 import numpy
 
-
 class StorageSet(set):
     def __init__(self,initializer=[],shape=(0,),storageType='d'):
         set.__init__(self,initializer)


### PR DESCRIPTION
This is a real small thing, but I think its good practice to have these import statements at the top of the module rather than inside a function declaration for two reasons
1. You can view all the imports in a single location ; and
2. The import only occurs once when the module occurs rather than every time the function is called.