### PR TITLE
Found two more log()'s in mprans that should be logEvents.

### DIFF
--- a/proteus/mprans/MCorr.py
+++ b/proteus/mprans/MCorr.py
@@ -599,9 +599,9 @@ class LevelModel(proteus.Transport.OneLevelTransport):
             self.mesh.exteriorElementBoundariesArray,
             self.mesh.elementBoundaryElementsArray,
             self.mesh.elementBoundaryLocalElementBoundariesArray)
-        log("Global residual",level=9,data=r)
+        logEvent("Global residual",level=9,data=r)
         self.coefficients.massConservationError = fabs(globalSum(r[:self.mesh.nNodes_owned].sum()))
-        log("   Mass Conservation Error",level=3,data=self.coefficients.massConservationError)
+        logEvent("   Mass Conservation Error",level=3,data=self.coefficients.massConservationError)
         self.nonlinear_function_evaluations += 1
         if self.globalResidualDummy == None:
             self.globalResidualDummy = numpy.zeros(r.shape,'d')


### PR DESCRIPTION
Not sure why they didn't cause issues earlier, but apparently this function gets used now.