### PR TITLE
Fixed bug that caused simulations to hang

### DIFF
--- a/proteus/WaveTools.pyx
+++ b/proteus/WaveTools.pyx
@@ -1375,7 +1375,7 @@ class RandomNLWavesFast:
         aR = RandomWaves(Tp,Hs,mwl,depth,waveDir,g,N,bandFactor,spectName,spectral_params,phi)
         aRN = RandomNLWaves(Tstart,Tend,Tp,Hs,mwl,depth,waveDir,g,N,bandFactor,spectName,spectral_params,phi)
         self.omega = aR.omega
-
+        self.mwl = mwl
 
         Tmax =  NLongW*Tp/1.1
         modes = ["short","linear","long"]
@@ -1389,7 +1389,7 @@ class RandomNLWavesFast:
             series = aRN.writeEtaSeries(Tstart,Tend,dt,x0,fname,mode,False,Vgen)
             Tstart_temp = series[0,0]
             cutoff = 0.2*periods[ii]/(Tend-Tstart_temp)
-            
+    
             #Checking if there are enough windows
             Nwaves_tot = int((Tend-Tstart_temp)/periods[ii])
             Nwaves = min(Nwaves,Nwaves_tot)


### PR DESCRIPTION
Bug that caused simulation to hang when BoundaryConditions class tried to use mwl from RandomNLWavesFast