### PR TITLE
Gauge support for air-water-vv refactor

### DIFF
--- a/proteus/mprans/SpatialTools.py
+++ b/proteus/mprans/SpatialTools.py
@@ -86,13 +86,23 @@ class ShapeRANS(Shape):
         if key not in self.auxiliaryVariables:
             if key == 'RigidBody':
                 self.auxiliaryVariables[key] = True
-            if key == 'RelaxZones':
+            elif key == 'RelaxZones':
                 self.auxiliaryVariables[key] = self.zones
-            if str(key).startswith('Gauge_'):
+            elif str(key).startswith('Gauge_'):
                 self.auxiliaryVariables[key] = [gauge]
-        elif str(key).startswith('Gauge_') \
-                and gauge not in self.auxiliaryVariables[key]:
-            self.auxiliaryVariables[key] += [gauge]
+            else:
+                logEvent("auxiliaryVariable key: "
+                         "{key} not recognized.".format(key=str(key)), level=1)
+        elif str(key).startswith('Gauge_'):
+            if gauge not in self.auxiliaryVariables[key]:
+                self.auxiliaryVariables[key] += [gauge]
+            else:
+                logEvent(
+                    "Attempted to put identical "
+                    "gauge at key: {key}".format(key=str(key)), level=1)
+        else:
+            logEvent("Key {key} is already attached.".format(key=str(key)),
+                     level=1)
 
     def attachPointGauges(self, model_key, gauges, activeTime=None,
                           sampleRate=0,

--- a/proteus/mprans/SpatialTools.py
+++ b/proteus/mprans/SpatialTools.py
@@ -66,7 +66,7 @@ class ShapeRANS(Shape):
         self.auxiliaryVariables = {}  # list of auxvar attached to shape
         self.It = None  # inertia tensor
 
-    def _attachAuxiliaryVariable(self, key):
+    def _attachAuxiliaryVariable(self, key, gauge=None):
         """
         Attaches an auxiliary variable to the auxiliaryVariables dictionary of
         the shape (used in buildDomain function)
@@ -75,6 +75,8 @@ class ShapeRANS(Shape):
         ----------
         key: string
             Dictionary key defining the auxiliaryVariable to attach
+
+        gauge: Gauges
 
         Notes
         -----
@@ -86,6 +88,60 @@ class ShapeRANS(Shape):
                 self.auxiliaryVariables[key] = True
             if key == 'RelaxZones':
                 self.auxiliaryVariables[key] = self.zones
+            if str(key).startswith('Gauge_'):
+                self.auxiliaryVariables[key] = [gauge]
+        elif str(key).startswith('Gauge_') \
+                and gauge not in self.auxiliaryVariables[key]:
+            self.auxiliaryVariables[key] += [gauge]
+
+    def attachPointGauges(self, model_key, gauges, activeTime=None,
+                          sampleRate=0,
+                          fileName='point_gauges.csv'):
+        """Attaches Point Gauges (in the Proteus/Gauges.py style) to the shape.
+
+        Parameters
+        ----------
+        model_key: string
+            Label of the model to use as a key for selecting particular gauges.
+        See proteus Gauges.py PointGauges class for the remaining parameters.
+        """
+        new_gauges = Gauges.PointGauges(gauges, activeTime, sampleRate,
+                                        fileName)
+        self._attachAuxiliaryVariable('Gauge_' + model_key,
+                                      gauge=new_gauges)
+
+    def attachLineGauges(self, model_key, gauges, activeTime=None,
+                         sampleRate=0,
+                         fileName='line_gauges.csv'):
+        """Attaches Line Gauges (in the Proteus/Gauges.py style) to the shape.
+
+        Parameters
+        ----------
+        model_key: string
+            Label of the model to use as a key for selecting particular gauges.
+        See proteus Gauges.py LineGauges class for the remaining parameters.
+        """
+        new_gauges = Gauges.LineGauges(gauges, activeTime, sampleRate,
+                                       fileName)
+        self._attachAuxiliaryVariable('Gauge_' + model_key,
+                                      gauge=new_gauges)
+
+    def attachLineIntegralGauges(self, model_key, gauges, activeTime=None,
+                                 sampleRate=0,
+                                 fileName='line_integral_gauges.csv'):
+        """Attaches Line Integral Gauges (in the Proteus/Gauges.py style).
+
+        Parameters
+        ----------
+        model_key: string
+            Label of the model to use as a key for selecting particular gauges.
+        See proteus Gauges.py LineIntegralGauges class for the remaining parameters.
+        """
+        new_gauges = Gauges.LineIntegralGauges(gauges, activeTime,
+                                               sampleRate, fileName)
+        self._attachAuxiliaryVariable('Gauge_' + model_key,
+                                      gauge=new_gauges)
+
 
     def setRigidBody(self, holes=None):
         """
@@ -1385,9 +1441,18 @@ def assembleAuxiliaryVariables(domain):
     -----
     Should be called after assembleGeometry
     """
-    domain.auxiliaryVariables = {'twp': [], 'vof': [], 'ls': [], 'redist': [],
-                                 'ls_consrv': [], 'kappa': [],
-                                 'dissipation': [], 'moveMesh': []}
+
+    domain.auxiliaryVariables = {
+        'dissipation': [],
+        'kappa': [],
+        'ls': [],
+        'ls_consrv': [],
+        'moveMesh': [],
+        'redist': [],
+        'twp': [],
+        'vof': []
+    }
+
     zones_global = {}
     start_region = 0
     start_rflag = 0
@@ -1430,6 +1495,24 @@ def assembleAuxiliaryVariables(domain):
                 key = flag+start_rflag
                 zones_global[key] = zone
         start_flag += len(shape.BC_list)
+        # ----------------------------
+        # GAUGES
+        gauge_dict = {key: shape.auxiliaryVariables.get(key,[])
+                      for key in shape.auxiliaryVariables.keys()
+                      if str(key).startswith('Gauge_')}
+        for key in gauge_dict.keys():
+            key_name = key.split('_', 1)[1] # Cutting off "Gauge_" prefix
+            if key_name not in aux:
+                # It is probably too dangerous to simply put "aux[key_name] = []"
+                # as this system is fragile to typos. Instead, we throw an error.
+                raise ValueError('ERROR: Gauge key ',
+                                 key_name,
+                                 ' is not a recognized model by SpatialTools.',
+                                 ' The known models in our dictionary are ',
+                                 str(aux.keys())
+                                 )
+            else:
+                aux[key_name] += gauge_dict[key]
         if shape.regions is not None:
             start_region += len(shape.regions)
             start_rflag += max(domain.regionFlags[0:start_region])

--- a/proteus/tests/test_spatialtools.py
+++ b/proteus/tests/test_spatialtools.py
@@ -9,7 +9,7 @@ import unittest
 import numpy.testing as npt
 import numpy as np
 from nose.tools import eq_
-from proteus import Comm, Profiling
+from proteus import Comm, Profiling, Gauges
 from proteus.Profiling import logEvent as log
 from proteus.Domain import (PiecewiseLinearComplexDomain,
                             PlanarStraightLineGraphDomain)
@@ -90,7 +90,6 @@ def create_tank2D(domain, dim=(0., 0.), coords=None, from_0=True):
 
 def create_tank3D(domain, dim=(0., 0., 0.), coords=None, from_0=True):
     return Tank3D(domain, dim, coords, from_0)
-
 
 class TestShapeDomainBuilding(unittest.TestCase):
 
@@ -222,6 +221,55 @@ class TestShapeDomainBuilding(unittest.TestCase):
 
 
 class TestShapeRANS(unittest.TestCase):
+
+    def test_gauges(self):
+        domain = create_domain2D()
+        tank = create_tank2D(domain)
+        tank.attachPointGauges('kappa',
+                               gauges = ((('k', ),((0.,0.,0.),)),),
+                               activeTime = (0.,1.),
+                               sampleRate = 0.5,
+                               fileName = 'point1.csv')
+        tank.attachLineGauges('kappa',
+                               gauges = ((('k', ),((0.,0.,0.),(0.,0.,1.))),),
+                               activeTime = (0.,2.),
+                               sampleRate = 0.5,
+                               fileName = 'line1.csv')
+        tank.attachLineIntegralGauges('vof',
+                                      gauges=(
+                                      (('vof',), ((0., 0., 0.), (0., 0., 1.))),),
+                                      activeTime=(0., 2.),
+                                      sampleRate=0.5,
+                                      fileName='line_int1.csv')
+        assert tank.auxiliaryVariables.get('Gauge_kappa', None) is not None
+        assert tank.auxiliaryVariables.get('Gauge_vof', None) is not None
+        assert len(tank.auxiliaryVariables['Gauge_kappa']) is 2
+        assert len(tank.auxiliaryVariables['Gauge_vof']) is 1
+        self.assertIsInstance(tank.auxiliaryVariables['Gauge_kappa'][0],
+                              Gauges.Gauges)
+        assert tank.auxiliaryVariables['Gauge_kappa'][0].activeTime == (0.,1.)
+        assert tank.auxiliaryVariables['Gauge_kappa'][1].activeTime == (0.,2.)
+        assert tank.auxiliaryVariables['Gauge_vof'][0].sampleRate == 0.5
+
+        assembleDomainRANS(domain)
+
+        assert domain.auxiliaryVariables.get('kappa', None) is not None
+        assert domain.auxiliaryVariables.get('vof', None) is not None
+        self.assertIsInstance(domain.auxiliaryVariables['vof'][0],
+                              Gauges.Gauges)
+        assert len(domain.auxiliaryVariables['kappa']) is 2
+        assert len(domain.auxiliaryVariables['vof']) is 1
+        assert domain.auxiliaryVariables['kappa'][0].activeTime == (0., 1.)
+        assert domain.auxiliaryVariables['kappa'][1].activeTime == (0., 2.)
+        assert domain.auxiliaryVariables['vof'][0].sampleRate == 0.5
+
+        tank.attachPointGauges('voff',
+                                gauges=((('vof',), ((0., 0., 0.),)),),
+                                activeTime=(0., 1.),
+                                sampleRate=0.5,
+                                fileName='point2.csv')
+        self.assertRaises(ValueError,assembleDomainRANS,domain)
+
 
     def test_rigid_body(self):
         domain = create_domain2D()


### PR DESCRIPTION
Users can now attach gauges to any RANS shape by the attachPointGauges() (or similar for line and line integral gauges) method, which uses the same inputs as a gauge call plus a label for which problem the gauges should be associated with (e.g. ls, twp, redist).  These are attached to the Domain and can be called from _n.py files in a simple manner.  Errors are raised for misnamed problems (i.e. if someone puts twp_navier_stokes despite us using the shortened name twp in this context).  _n.py files may call for their auxiliary variables whether or not they have any without bad behavior (allow people to turn gauges or other factors on and off without worrying about editing _n.py files).