### PR TITLE
removed time dependence from the pressure subgrid error

### DIFF
--- a/proteus/mprans/RANS2P.h
+++ b/proteus/mprans/RANS2P.h
@@ -1026,7 +1026,8 @@ namespace proteus
       cfl = nrm_df/(h*density);//this is really cfl/dt, but that's what we want to know, the step controller expect this
       oneByAbsdt =  fabs(dmt);
       tau_v = 1.0/(4.0*viscosity/(h*h) + 2.0*nrm_df/h + oneByAbsdt);
-      tau_p = (4.0*viscosity + 2.0*nrm_df*h + oneByAbsdt*h*h)/pfac;
+      //tau_p = (4.0*viscosity + 2.0*nrm_df*h + oneByAbsdt*h*h)/pfac;
+      tau_p = (4.0*viscosity + 2.0*nrm_df*h)/pfac;
       /* std::cout<<"tau_v "<<tau_v<<" tau_p "<<tau_p<<std::endl; */
     }
 
@@ -1049,7 +1050,8 @@ namespace proteus
          for (int J=0;J<nSpace;J++) 
            v_d_Gv += Ai[I]*G[I*nSpace+J]*Ai[J];
       tau_v = 1.0/sqrt(Ct_sge*A0*A0 + v_d_Gv + Cd_sge*Kij*Kij*G_dd_G + 1.0e-12); 
-      tau_p = 1.0/(pfac*tr_G*tau_v);     
+      //tau_p = 1.0/(pfac*tr_G*tau_v);
+      tau_p = sqrt(v_d_Gv + Cd_sge*Kij*Kij*G_dd_G)/(pfac*tr_G); 
     }
 
     inline

--- a/proteus/mprans/RANS2P.py
+++ b/proteus/mprans/RANS2P.py
@@ -408,11 +408,11 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
             self.barycenters = numpy.zeros((nBoundariesMax,3),'d')
         comm = Comm.get()
         import os
-        # if comm.isMaster():
-        #     self.wettedAreaHistory = open(os.path.join(proteus.Profiling.logDir,"wettedAreaHistory.txt"),"w")
-        #     self.forceHistory_p = open(os.path.join(proteus.Profiling.logDir,"forceHistory_p.txt"),"w")
-        #     self.forceHistory_v = open(os.path.join(proteus.Profiling.logDir,"forceHistory_v.txt"),"w")
-        #     self.momentHistory = open(os.path.join(proteus.Profiling.logDir,"momentHistory.txt"),"w")
+        if comm.isMaster():
+            self.wettedAreaHistory = open(os.path.join(proteus.Profiling.logDir,"wettedAreaHistory.txt"),"w")
+            self.forceHistory_p = open(os.path.join(proteus.Profiling.logDir,"forceHistory_p.txt"),"w")
+            self.forceHistory_v = open(os.path.join(proteus.Profiling.logDir,"forceHistory_v.txt"),"w")
+            self.momentHistory = open(os.path.join(proteus.Profiling.logDir,"momentHistory.txt"),"w")
         self.comm = comm
     #initialize so it can run as single phase
     def initializeElementQuadrature(self,t,cq):
@@ -684,20 +684,20 @@ class Coefficients(proteus.TransportCoefficients.TC_base):
     def postStep(self,t,firstStep=False):
         self.model.dt_last = self.model.timeIntegration.dt
         self.model.q['dV_last'][:] = self.model.q['dV']
-        # if self.comm.isMaster():
+        if self.comm.isMaster():
             #print "wettedAreas"
             #print self.wettedAreas[:]
             #print "Forces_p"
             #print self.netForces_p[:,:]
             #print "Forces_v"
             #print self.netForces_v[:,:]
-            # self.wettedAreaHistory.write("%21.16e\n" % (self.wettedAreas[-1],))
-            # self.forceHistory_p.write("%21.16e %21.16e %21.16e\n" %tuple(self.netForces_p[-1,:]))
-            # self.forceHistory_p.flush()
-            # self.forceHistory_v.write("%21.16e %21.16e %21.16e\n" %tuple(self.netForces_v[-1,:]))
-            # self.forceHistory_v.flush()
-            # self.momentHistory.write("%21.15e %21.16e %21.16e\n" % tuple(self.netMoments[-1,:]))
-            # self.momentHistory.flush()
+            self.wettedAreaHistory.write("%21.16e\n" % (self.wettedAreas[-1],))
+            self.forceHistory_p.write("%21.16e %21.16e %21.16e\n" %tuple(self.netForces_p[-1,:]))
+            self.forceHistory_p.flush()
+            self.forceHistory_v.write("%21.16e %21.16e %21.16e\n" %tuple(self.netForces_v[-1,:]))
+            self.forceHistory_v.flush()
+            self.momentHistory.write("%21.15e %21.16e %21.16e\n" % tuple(self.netMoments[-1,:]))
+            self.momentHistory.flush()
 
 class LevelModel(proteus.Transport.OneLevelTransport):
     nCalls=0

--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -1025,7 +1025,8 @@ namespace proteus
       cfl = nrm_df/(h*density);//this is really cfl/dt, but that's what we want to know, the step controller expect this
       oneByAbsdt =  fabs(dmt);
       tau_v = 1.0/(4.0*viscosity/(h*h) + 2.0*nrm_df/h + oneByAbsdt);
-      tau_p = (4.0*viscosity + 2.0*nrm_df*h + oneByAbsdt*h*h)/pfac;
+      //tau_p = (4.0*viscosity + 2.0*nrm_df*h + oneByAbsdt*h*h)/pfac;
+      tau_p = (4.0*viscosity + 2.0*nrm_df*h)/pfac;
       /* std::cout<<"tau_v "<<tau_v<<" tau_p "<<tau_p<<std::endl; */
     }
 
@@ -1048,7 +1049,8 @@ namespace proteus
          for (int J=0;J<nSpace;J++) 
            v_d_Gv += Ai[I]*G[I*nSpace+J]*Ai[J];
       tau_v = 1.0/sqrt(Ct_sge*A0*A0 + v_d_Gv + Cd_sge*Kij*Kij*G_dd_G + 1.0e-12); 
-      tau_p = 1.0/(pfac*tr_G*tau_v);     
+      //tau_p = 1.0/(pfac*tr_G*tau_v);     
+      tau_p = sqrt(v_d_Gv + Cd_sge*Kij*Kij*G_dd_G)/(pfac*tr_G); 
     }
 
     inline


### PR DESCRIPTION
@adimako @tridelat @Giovanni-Cozzuto-1989 : I was reading about subgrid scale turbulence modeling with methods very similar to what we have in RANS2P, but I noticed that they don't include the term that depends on the time step size within the pressure subgrid error term. If it's easy, could you check one of the tests that showed pressure spikes when the time step size is cut to match the output? I ran this branch on a floating_bar test and the pressure looks smoother. BTW, because the modified formula is in RANS2P.h and RANS2P2D.h you'll have to run 'make develop' (or make install if that's how you build proteus) to rebuilt the RANS2P module. 
