### PR TITLE
Fixed leaks - cherry pick from hydra/stable

### DIFF
--- a/proteus/WaveTools.h
+++ b/proteus/WaveTools.h
@@ -17,7 +17,7 @@ namespace proteus
  const double 	Pi17_ =  (1.7*PI_);
 
 
- inline double fastcosh(double k, double Z , bool cosh)
+ inline void fastcosh(double * hype, double k, double Z )
  {
 
        double Kd = k * Z;
@@ -30,17 +30,8 @@ namespace proteus
        double  Kd8 = Kd7 * Kd*1.2500000000E-01; 
        double Kd9 = Kd8 * Kd*1.1111111111E-01;
        double  Kd10 =Kd9 * Kd*0.1;
-       double hype = 0.;
-       if(cosh)
-	 {
-	   hype = 1. + Kd2  + Kd4  + Kd6   + Kd8   + Kd10;
-	 }
-       else
-	 {
-	   hype =      Kd   + Kd3  + Kd5   + Kd7   + Kd9;
-	 }
-       
-       return hype;
+       hype[0] = 1. + Kd2  + Kd4  + Kd6   + Kd8   + Kd10;
+       hype[1] =      Kd   + Kd3  + Kd5   + Kd7   + Kd9;
      
  }
 
@@ -133,16 +124,14 @@ namespace proteus
      double Z =  (vDir[0]*x[0] + vDir[1]*x[1]+ vDir[2]*x[2]) - mwl;
      double Uhype =0.;
      double Vhype =0.;
-     double fcosh =0.;
-     double fsinh =0.;
-
+     double hype[2] = {0};
       
      if(kAbs*Z > -PI_)
        {
-	 fcosh = fastcosh(kAbs, Z,  true); 
-	 fsinh = fastcosh(kAbs, Z,  false); 
-	 Uhype = fcosh / tanhkd + fsinh; 
-	 Vhype = fsinh / tanhkd + fcosh; 
+	 fastcosh(hype,kAbs, Z); 
+
+	 Uhype = hype[0] / tanhkd + hype[1]; 
+	 Vhype = hype[1]/ tanhkd + hype[0]; 
        }
      double fcos = fastcos(phase);
      double fsin = fastcos(Pihalf_ - phase);

--- a/proteus/WaveTools.h
+++ b/proteus/WaveTools.h
@@ -91,8 +91,9 @@ namespace proteus
 
   }
 
-
- inline double* __cpp_vel_mode(double x[nDim], double t, double kDir[nDim],double kAbs, double omega, double phi, double amplitude,double mwl, double depth, double waveDir[nDim], double vDir[nDim], double tanhkd)
+ /*
+ inline double* __cpp_vel_mode(double * x, double t, double *kDir,double kAbs, double omega, double phi, double amplitude,double mwl, double depth, double *waveDir, double *vDir, double tanhkd)
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
    {
 
      double phase = x[0]*kDir[0]+x[1]*kDir[1]+x[2]*kDir[2] - omega*t  + phi;
@@ -118,13 +119,45 @@ namespace proteus
       double UH=amplitude*omega*Uhype*fcos;
       double UV=amplitude*omega*Vhype*fsin;
      //Setting wave direction
-      for(int ii=0; ii<nDim ; ii++)
-	  {
-	    VV[ii] = UH*waveDir[ii] + UV*vDir[ii];
-	  }
-      return VV;
-      delete [] VV;
-      }
+     for(int ii=0; ii<nDim ; ii++)
+       {
+	 VV[ii] = UH*waveDir[ii] + UV*vDir[ii];
+       }
+     return VV;
+     delete [] VV;
+   }
+ */
+ inline void __cpp_vel_mode_p(double* U, double  x[nDim], double t, double kDir[nDim],double kAbs, double omega, double phi, double amplitude,double mwl, double depth, double waveDir[nDim], double vDir[nDim], double tanhkd)
+   {
+     double phase = x[0]*kDir[0]+x[1]*kDir[1]+x[2]*kDir[2] - omega*t  + phi;
+     double Z =  (vDir[0]*x[0] + vDir[1]*x[1]+ vDir[2]*x[2]) - mwl;
+     double Uhype =0.;
+     double Vhype =0.;
+     double fcosh =0.;
+     double fsinh =0.;
+
+      
+     if(kAbs*Z > -PI_)
+       {
+	 fcosh = fastcosh(kAbs, Z,  true); 
+	 fsinh = fastcosh(kAbs, Z,  false); 
+	 Uhype = fcosh / tanhkd + fsinh; 
+	 Vhype = fsinh / tanhkd + fcosh; 
+       }
+     double fcos = fastcos(phase);
+     double fsin = fastcos(Pihalf_ - phase);
+     
+     double UH=amplitude*omega*Uhype*fcos;
+     double UV=amplitude*omega*Vhype*fsin;
+     //Setting wave direction
+     for(int ii=0; ii<nDim ; ii++)
+       {
+	 U[ii] += UH*waveDir[ii] + UV*vDir[ii];
+       }
+
+   }
+ 
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
 
 
  
@@ -158,8 +191,8 @@ namespace proteus
         return HH/kAbs;
       }
 
- inline double* __cpp_uFenton(double x[nDim],double t,double kDir[nDim],double kAbs,double omega,double phi0,double amplitude,
-			      double mwl, double depth, double gAbs, int Nf, double* Bcoeff ,double* mV, double waveDir[nDim], double vDir[nDim], double* tanhF)
+ inline void __cpp_uFenton(double* U, double x[nDim],double t,double kDir[nDim],double kAbs,double omega,double phi0,double amplitude,
+			      double mwl, double depth, double gAbs, int Nf, double* Bcoeff ,double mV[nDim], double waveDir[nDim], double vDir[nDim], double* tanhF)
 
 
       {
@@ -170,12 +203,6 @@ namespace proteus
 	double phi = 0.;
 	double kmode = 0.;
 	double amp = 0.;
-	double* Ufenton;
-	double* Uf;
-	Uf = new double[nDim];
-	Uf[0] = 0.;
-	Uf[1] = 0.;
-	Uf[2] = 0.;
 
 	double sqrtAbs(sqrt(gAbs/kAbs));
 
@@ -191,22 +218,15 @@ namespace proteus
 	    kw[2] = ii*kDir[2];
 	    phi = ii*phi0;
             amp = tanhF[nn]*sqrtAbs*Bcoeff[nn]/omega;
-	    Ufenton = __cpp_vel_mode(x, t ,kw, kmode, om, phi, amp, mwl, depth, waveDir, vDir, tanhF[nn]); 
-	    Uf[0] = Uf[0]+ *(Ufenton);//[0];
-	    Uf[1] = Uf[1]+ *(Ufenton+1);//[1];
-	    Uf[2] = Uf[2]+ *(Ufenton+2);//[2];
+	    __cpp_vel_mode_p(U,x, t ,kw, kmode, om, phi, amp, mwl, depth, waveDir, vDir, tanhF[nn]); 
 
 	  }
 	
 	for ( int kk = 0; kk<3; kk++)
 	  {
-	    Uf[kk] = Uf[kk]+mV[kk];
-	    }
+	    U[kk] = U[kk]+mV[kk];
+	  }
 
-        return Uf;
-
-	delete [] Ufenton;      
-	delete [] Uf;
 
 
       
@@ -238,18 +258,12 @@ namespace proteus
         return HH;
       }
 
- inline double* __cpp_uRandom(double x[nDim],double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double waveDir[nDim], double vDir[nDim], double* tanhF )
+ inline void __cpp_uRandom(double * U, double x[nDim],double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double waveDir[nDim], double vDir[nDim], double* tanhF )
 
 
       {
 
 	double kw[nDim] = {0.,0.,0.};
-	double* Ufenton;
-	double* Uf;
-	Uf = new double[nDim];
-	Uf[0] = 0.;
-	Uf[1] = 0.;
-	Uf[2] = 0.;
 
 
 	int ii =0;
@@ -260,37 +274,24 @@ namespace proteus
 	    kw[0] = kDir[ii];
 	    kw[1] = kDir[ii+1];
 	    kw[2] = kDir[ii+2];
-	    Ufenton = __cpp_vel_mode(x, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, waveDir, vDir, tanhF[nn]); 
-	    Uf[0] = Uf[0]+ *(Ufenton);//[0];
-	    Uf[1] = Uf[1]+ *(Ufenton+1);//[1];
-	    Uf[2] = Uf[2]+ *(Ufenton+2);//[2];
+	    __cpp_vel_mode_p(U,x, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, waveDir, vDir, tanhF[nn]); 
 
 	  }
 	
-        return Uf;
 
-	delete [] Ufenton;      
-	delete [] Uf;
 
 
       
  }
 //---------------------------------------------------------Directional RANDOM / Velocity-------------------------------------------------------------------------
 
- inline double* __cpp_uDir(double x[nDim],double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double vDir[nDim], double* tanhF )
+ inline void __cpp_uDir(double * U, double x[nDim],double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double vDir[nDim], double* tanhF )
 
 
       {
 
 	double kw[nDim] = {0.,0.,0.};
 	double wd[nDim] = {0.,0.,0.};
-	double* Ufenton;
-	double* Uf;
-	Uf = new double[nDim];
-	Uf[0] = 0.;
-	Uf[1] = 0.;
-	Uf[2] = 0.;
-
 
 	int ii =0;
 
@@ -303,17 +304,10 @@ namespace proteus
 	    wd[0] = waveDir[ii];
 	    wd[1] = waveDir[ii+1];
 	    wd[2] = waveDir[ii+2];
-	    Ufenton = __cpp_vel_mode(x, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, wd, vDir, tanhF[nn]); 
-	    Uf[0] = Uf[0]+ *(Ufenton);
-	    Uf[1] = Uf[1]+ *(Ufenton+1);
-	    Uf[2] = Uf[2]+ *(Ufenton+2);
+	    __cpp_vel_mode_p(U,x, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, wd, vDir, tanhF[nn]); 
 
 	  }
 	
-        return Uf;
-
-	delete [] Ufenton;      
-	delete [] Uf;
 
 
       }    
@@ -340,11 +334,12 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
 
 
 { 
-  x[0] = x[0] - x0[0];
-  x[1] = x[1] - x0[1];
-  x[2] = x[2] - x0[2];
+   double xx[3];
+   xx[0] = x[0] - x0[0];
+   xx[1] = x[1] - x0[1];
+   xx[2] = x[2] - x0[2];
 
-  return __cpp_etaRandom(x,  t,  kDir,  omega,  phi,  amplitude,  N); 
+  return __cpp_etaRandom(xx,  t,  kDir,  omega,  phi,  amplitude,  N); 
 }
 
 
@@ -352,16 +347,17 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
 
 
    
- inline double* __cpp_uDirect(double* x, double* x0, double t, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
+ inline void __cpp_uDirect(double * U, double x[nDim], double x0[nDim], double t, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double vDir[nDim], double* tanhKd )
 
 
 
  {
-	x[0] = x[0] - x0[0];
-	x[1] = x[1] - x0[1];
-	x[2] = x[2] - x0[2];
+   double xx[3];
+   xx[0] = x[0] - x0[0];
+   xx[1] = x[1] - x0[1];
+   xx[2] = x[2] - x0[2];
 
-	return __cpp_uRandom(x, t,  kDir,  kAbs,  omega,  phi,  amplitude,  mwl,  depth,  N,  waveDir,  vDir,  tanhKd );
+   __cpp_uRandom(U, xx, t,  kDir,  kAbs,  omega,  phi,  amplitude,  mwl,  depth,  N,  waveDir,  vDir,  tanhKd );
 
  }
 
@@ -371,9 +367,10 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
 
 { 
   int Is = Nw*N;
-  x[0] = x[0] - x0[0];
-  x[1] = x[1] - x0[1];
-  x[2] = x[2] - x0[2];
+  double xx[3];
+  xx[0] = x[0] - x0[0];
+  xx[1] = x[1] - x0[1];
+  xx[2] = x[2] - x0[2];
   t = t-t0[Nw];
   double HH = 0.;
   double kw[nDim] = {0.,0.,0.};
@@ -385,7 +382,7 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
 	    kw[0] = kDir[ii];
 	    kw[1] = kDir[ii+1];
 	    kw[2] = kDir[ii+2];
-	    HH= HH + __cpp_eta_mode(x,t,kw,omega[nn],phi[nn],amplitude[nn]);
+	    HH= HH + __cpp_eta_mode(xx,t,kw,omega[nn],phi[nn],amplitude[nn]);
 	  }
   return HH;
 
@@ -394,24 +391,19 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
 
 
 
- inline double* __cpp_uWindow(double* x, double* x0, double t, double* t0, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N,int Nw, double* waveDir, double* vDir, double* tanhF )
+ inline double* __cpp_uWindow(double* U, double x[nDim], double x0[nDim], double t, double* t0, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N,int Nw, double* waveDir, double* vDir, double* tanhF )
 
 
  {
   int Is = Nw*N;
-  x[0] = x[0] - x0[0];
-  x[1] = x[1] - x0[1];
-  x[2] = x[2] - x0[2];
+  double xx[3];
+  xx[0] = x[0] - x0[0];
+  xx[1] = x[1] - x0[1];
+  xx[2] = x[2] - x0[2];
   t = t-t0[Nw];
 
   double kw[nDim] = {0.,0.,0.};
-  double* Ufenton;
-  double* Uf;
-  Uf = new double[nDim];
-  Uf[0] = 0.;
-  Uf[1] = 0.;
-  Uf[2] = 0.;
-
+  
 
   int ii =0;
 
@@ -421,17 +413,10 @@ inline double __cpp_etaDirect(double x[nDim], double x0[nDim], double t, double*
       kw[0] = kDir[ii];
       kw[1] = kDir[ii+1];
       kw[2] = kDir[ii+2];
-      Ufenton = __cpp_vel_mode(x, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, waveDir, vDir, tanhF[nn]); 
-      Uf[0] = Uf[0]+ *(Ufenton);//[0];
-      Uf[1] = Uf[1]+ *(Ufenton+1);//[1];
-      Uf[2] = Uf[2]+ *(Ufenton+2);//[2];
+      __cpp_vel_mode_p(U, xx, t ,kw, kAbs[nn], omega[nn], phi[nn], amplitude[nn], mwl, depth, waveDir, vDir, tanhF[nn]); 
 
     }
 	
-        return Uf;
-
-	delete [] Ufenton;      
-	delete [] Uf;
 
 
       

--- a/proteus/WaveTools.h
+++ b/proteus/WaveTools.h
@@ -84,7 +84,6 @@ namespace proteus
 
  /*
  inline double* __cpp_vel_mode(double * x, double t, double *kDir,double kAbs, double omega, double phi, double amplitude,double mwl, double depth, double *waveDir, double *vDir, double tanhkd)
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
    {
 
      double phase = x[0]*kDir[0]+x[1]*kDir[1]+x[2]*kDir[2] - omega*t  + phi;
@@ -146,7 +145,6 @@ namespace proteus
 
    }
  
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
 
 
  

--- a/proteus/WaveTools.pxd
+++ b/proteus/WaveTools.pxd
@@ -9,7 +9,7 @@ from libcpp cimport bool
 
 cdef extern from "WaveTools.h" namespace "proteus":
     cdef const int nDim
-    cdef double fastcosh(double k, double Z,  bool cosh)
+    cdef double fastcosh(double * hype,double k, double Z)
     cdef double fastcos(double phase)
     cdef double __cpp_eta_mode(double* x, double t, double* kDir, double omega, double phi, double amplitude)
     cdef double __cpp_etaFenton(double* x, double t, double* kDir, double kAbs, double omega, double phi0, double amplitude, int Nf, double* Ycoeff)

--- a/proteus/WaveTools.pxd
+++ b/proteus/WaveTools.pxd
@@ -12,26 +12,26 @@ cdef extern from "WaveTools.h" namespace "proteus":
     cdef double fastcosh(double k, double Z,  bool cosh)
     cdef double fastcos(double phase)
     cdef double __cpp_eta_mode(double* x, double t, double* kDir, double omega, double phi, double amplitude)
-    cdef double* __cpp_vel_mode(double* x, double t, double* kDir, double kAbs, double omega, double phi, double amplitude, double mwl, double depth, double* waveDir, double* vDir, double tanhkd)
     cdef double __cpp_etaFenton(double* x, double t, double* kDir, double kAbs, double omega, double phi0, double amplitude, int Nf, double* Ycoeff)
-    cdef double* __cpp_uFenton(double* x, double t, double* kDir, double kAbs, double omega, double phi0, double amplitude, double mwl, double depth,double gAbs, int Nf, double* Bcoeff, double* mV, double* waveDir, double* vDir, double* tanhF)
+    cdef void __cpp_uFenton(double * U,double* x, double t, double* kDir, double kAbs, double omega, double phi0, double amplitude, double mwl, double depth,double gAbs, int Nf, double* Bcoeff, double* mV, double* waveDir, double* vDir, double* tanhF)
     cdef double __cpp_etaRandom(double* x, double t, double* kDir, double* omega, double* phi, double* amplitude, int N)
-    cdef double* __cpp_uRandom(double* x,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
-    cdef double* __cpp_uDir(double* x,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
+    cdef void __cpp_uRandom(double * U, double* x,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
+    cdef void __cpp_uDir(double* U, double* x,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
     cdef int __cpp_findWindow(double t, double handover, double t0, double Twindow, int Nwindows, double* windows_handover)
     cdef double __cpp_etaDirect(double* x, double* x0, double t, double* kDir, double* omega, double* phi, double* amplitude, int N)
-    cdef double* __cpp_uDirect(double* x,double* x0,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
+    cdef void __cpp_uDirect(double* U, double* x,double* x0,double t,double* kDir,double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N, double* waveDir, double* vDir, double* tanhKd )
     cdef double __cpp_etaWindow(double* x, double* x0, double t, double* t0, double* kDir, double* omega, double* phi, double* amplitude, int N, int Nw)
-    cdef  double* __cpp_uWindow(double* x, double* x0, double t, double* T0, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N,int Nw, double* waveDir, double* vDir, double* tanhKd )
+    cdef  void __cpp_uWindow(double* U,double* x, double* x0, double t, double* T0, double* kDir, double* kAbs, double* omega, double* phi, double* amplitude, double mwl, double depth, int N,int Nw, double* waveDir, double* vDir, double* tanhKd )
     cdef double __cpp_eta2nd(double* x, double t, double* kDir, double* ki, double* omega, double* phi, double* amplitude, int N, double* sinhKd, double* tanhKd)
     cdef double __cpp_eta_short(double* x, double t, double* kDir, double* ki, double* omega, double* phi, double* amplitude, int N, double* sinhKd, double* tanhKd, double gAbs)
     cdef double __cpp_eta_long(double* x, double t, double* kDir, double* ki, double* omega, double* phi, double* amplitude, int N, double* sinhKd, double* tanhKd, double gAbs)
+    cdef void __cpp_vel_mode_p(double* U, double * x, double t, double *kDir,double kAbs, double omega, double phi, double amplitude,double mwl, double depth, double *waveDir, double *vDir, double tanhkd)
 
 # pointer to eta function
 ctypedef double (*cfeta) (MonochromaticWaves, double* , double )  
 
 # pointer to velocity function
-ctypedef double* (*cfvel) (MonochromaticWaves, double* , double )
+ctypedef void (*cfvel) (MonochromaticWaves, double*, double* , double )
 
 
 
@@ -61,8 +61,8 @@ cdef class  MonochromaticWaves:
     cdef object waveType
     cdef double etaLinear(self, double* x, double t)
     cdef double etaFenton(self, double* x, double t)
-    cdef double* uLinear(self, double* x, double t)
-    cdef double* uFenton(self, double* x, double t)
+    cdef void uLinear(self, double* U, double* x, double t)
+    cdef void uFenton(self, double* U, double* x, double t)
 
 cdef class RandomWaves:
 
@@ -87,8 +87,8 @@ cdef class RandomWaves:
         int N
         np.ndarray fi,fim,Si_Jm,ki,omega,tanhF,g,waveDir,vDir,kDir,ai
         cdef object phi
-    cdef double _cpp_eta(self, double* x, double t)
-    cdef double* _cpp_u(self, double* x, double t)
+    cdef double _cpp_eta(self , double* x, double t)
+    cdef void _cpp_u(self, double *U, double* x, double t)
 
 
 
@@ -114,7 +114,7 @@ cdef class MultiSpectraRandomWaves:
     cdef public:
         double mwl,depth
     cdef double _cpp_eta(self, double* x, double t)
-    cdef double* _cpp_u(self, double* x, double t)
+    cdef void _cpp_u(self, double* U, double* x, double t)
 
 cdef class DirectionalWaves:
     cdef int Nall,Mtot,N
@@ -138,14 +138,14 @@ cdef class DirectionalWaves:
     cdef public:
         double mwl,depth
     cdef double _cpp_eta(self, double* x, double t)
-    cdef double* _cpp_u(self, double* x, double t)
+    cdef void _cpp_u(self, double* U, double* x, double t)
 
 
 # pointer to eta function
 ctypedef double (*cfeta2) (TimeSeries, double* , double )  
 
 # pointer to velocity function
-ctypedef double* (*cfvel2) (TimeSeries, double* , double )
+ctypedef void (*cfvel2) (TimeSeries, double*, double* , double )
 
 cdef class  TimeSeries:
     cdef bool rec_direct
@@ -182,8 +182,8 @@ cdef class  TimeSeries:
     cdef cfvel2 _cpp_u
     cdef double _cpp_etaDirect(self, double* x, double t) 
     cdef double _cpp_etaWindow(self, double* x, double t) 
-    cdef double* _cpp_uDirect(self, double* x, double t) 
-    cdef double* _cpp_uWindow(self, double* x, double t) 
+    cdef void _cpp_uDirect(self, double* U,double* x, double t) 
+    cdef void _cpp_uWindow(self, double* U, double* x, double t) 
 
 cdef class RandomNLWaves:
     cdef np.ndarray omega,ki,kDir,phi,tanhKd,sinhKd,waveDir,ai

--- a/proteus/WaveTools.py
+++ b/proteus/WaveTools.py
@@ -74,7 +74,9 @@ def fastcosh_test(k,Z):
     cos(phi)
 
     """
-    return fastcosh(k,Z,True)
+    cython.declare(xx=cython.double[2])
+    fastcosh(xx,k,Z)
+    return xx[0]
 def fastsinh_test(k,Z):
     """Fast hyperbolic sine function with Taylor approximation - TO BE USED FOR TESTING"
     Parameters
@@ -87,7 +89,10 @@ def fastsinh_test(k,Z):
     cos(phi)
 
     """
-    return fastcosh(k,Z,False)
+    cython.declare(xx=cython.double[2])
+    fastcosh(xx,k,Z)
+    return xx[1]
+
 
 def coshkzd_test(k,Z,d):
     return fastcosh_test(k,Z) / np.tanh(k*d) + fastsinh_test(k,Z)

--- a/proteus/WaveTools.py
+++ b/proteus/WaveTools.py
@@ -782,15 +782,8 @@ class  MonochromaticWaves:
         return __cpp_etaFenton(x,t,self.kDir_, self.k, self.omega,self.phi0,self.amplitude, self.Nf, self.Ycoeff_)
 
 
-<<<<<<< HEAD
-    def  uLinear(self,  x,  t):
-
-        
-        return __cpp_vel_mode(x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl,self.depth,self.waveDir_,self.vDir_, self.tanhL)
-=======
     def  uLinear(self, U, x,  t):        
         __cpp_vel_mode_p(U, x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl,self.depth,self.waveDir_,self.vDir_, self.tanhL)
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
 
     def  uFenton(self,  U, x,  t):
         __cpp_uFenton(U,x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl, self.depth, self.gAbs,self.Nf, self.Bcoeff_, self.mV_,self.waveDir_,self.vDir_, self.tanhF_)
@@ -835,23 +828,6 @@ class  MonochromaticWaves:
 
         """
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-        U = np.zeros(3,)
-        if self.waveType =="Linear":
-            cppUL = self.uLinear(xx,t)            
-            U[0] = cppUL[0]
-            U[1] = cppUL[1]
-            U[2] = cppUL[2]
-
-        else:
-            cppUF = self.uFenton(xx,t)            
-            U[0] = cppUF[0]
-            U[1] = cppUF[1]
-            U[2] = cppUF[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
@@ -869,8 +845,6 @@ class  MonochromaticWaves:
             U[0] = cppU[0]
             U[1] = cppU[1]
             U[2] = cppU[2]
-
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         return U
 
     
@@ -1059,16 +1033,10 @@ class RandomWaves:
         """
 
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
             cppU[ii] = 0.
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
         self._cpp_u(cppU,xx,t)            
         U[0] = cppU[0]
@@ -1310,16 +1278,10 @@ class MultiSpectraRandomWaves:
         """
 
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
             cppU[ii] = 0.
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
         self._cpp_u(cppU,xx,t)            
         U[0] = cppU[0]
@@ -1563,16 +1525,10 @@ class DirectionalWaves:
         """
 
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
             cppU[ii] = 0.
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
         self._cpp_u(cppU,xx,t)            
         U[0] = cppU[0]
@@ -2007,16 +1963,10 @@ class TimeSeries:
         """
 
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
             cppU[ii] = 0.
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
         self._cpp_uDirect(cppU,xx,t)            
         U[0] = cppU[0]
@@ -2058,7 +2008,7 @@ class TimeSeries:
             Position vector
         t : float
             Time variable
-<
+
         Returns
         --------
         float
@@ -2088,16 +2038,10 @@ class TimeSeries:
 
         """
         cython.declare(xx=cython.double[3])
-<<<<<<< HEAD
-        xx[0] = x[0]
-        xx[1] = x[1]
-        xx[2] = x[2]
-=======
         cython.declare(cppU=cython.double[3])
         for ii in range(3):
             xx[ii] = x[ii]
             cppU[ii] = 0.
->>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
         self._cpp_uWindow(cppU,xx,t)            
         U[0] = cppU[0]

--- a/proteus/WaveTools.py
+++ b/proteus/WaveTools.py
@@ -777,14 +777,18 @@ class  MonochromaticWaves:
         return __cpp_etaFenton(x,t,self.kDir_, self.k, self.omega,self.phi0,self.amplitude, self.Nf, self.Ycoeff_)
 
 
+<<<<<<< HEAD
     def  uLinear(self,  x,  t):
 
         
         return __cpp_vel_mode(x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl,self.depth,self.waveDir_,self.vDir_, self.tanhL)
+=======
+    def  uLinear(self, U, x,  t):        
+        __cpp_vel_mode_p(U, x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl,self.depth,self.waveDir_,self.vDir_, self.tanhL)
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
 
-    def  uFenton(self,  x,  t):
-        
-        return __cpp_uFenton(x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl, self.depth, self.gAbs,self.Nf, self.Bcoeff_, self.mV_,self.waveDir_,self.vDir_, self.tanhF_)
+    def  uFenton(self,  U, x,  t):
+        __cpp_uFenton(U,x, t, self.kDir_,self.k,self.omega,self.phi0,self.amplitude,self.mwl, self.depth, self.gAbs,self.Nf, self.Bcoeff_, self.mV_,self.waveDir_,self.vDir_, self.tanhF_)
 
     def eta(self,x,t):
         """Calculates free surface elevation (MonochromaticWaves class)
@@ -826,6 +830,7 @@ class  MonochromaticWaves:
 
         """
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
@@ -841,6 +846,26 @@ class  MonochromaticWaves:
             U[0] = cppUF[0]
             U[1] = cppUF[1]
             U[2] = cppUF[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+
+
+        U = np.zeros(3,)
+        if self.waveType =="Linear":
+            self.uLinear(cppU,xx,t)
+            U[0] = cppU[0]
+            U[1] = cppU[1]
+            U[2] = cppU[2]
+        else:
+            self.uFenton(cppU,xx,t)            
+            U[0] = cppU[0]
+            U[1] = cppU[1]
+            U[2] = cppU[2]
+
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         return U
 
     
@@ -1009,9 +1034,8 @@ class RandomWaves:
         xx[2] = x[2]
         return self._cpp_eta(xx,t)
 
-    def _cpp_u(self,  x,  t):
-
-        return __cpp_uRandom(x,t,self.kDir_, self.ki_, self.omega_,self.phi_,self.ai_,self.mwl,self.depth, self.N, self.waveDir_, self.vDir_, self.tanh_)
+    def _cpp_u(self,  U, x,  t):
+        __cpp_uRandom(U, x,t,self.kDir_, self.ki_, self.omega_,self.phi_,self.ai_,self.mwl,self.depth, self.N, self.waveDir_, self.vDir_, self.tanh_)
 
     def u(self, x, t):
         """Calculates wave velocity vector (RandomWaves class)
@@ -1030,14 +1054,21 @@ class RandomWaves:
         """
 
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
-        cppUL = self._cpp_u(xx,t)            
-        U[0] = cppUL[0]
-        U[1] = cppUL[1]
-        U[2] = cppUL[2]
+        self._cpp_u(cppU,xx,t)            
+        U[0] = cppU[0]
+        U[1] = cppU[1]
+        U[2] = cppU[2]
 
         return U
     def writeEtaSeries(self,Tstart,Tend,x0,fname,Vgen= np.array([0.,0,0])):
@@ -1253,9 +1284,9 @@ class MultiSpectraRandomWaves:
         xx[2] = x[2]
         return self._cpp_eta(xx,t)
 
-    def _cpp_u(self,  x,  t):
+    def _cpp_u(self,  U, x,  t):
 
-        return __cpp_uDir(x,t,self.kDirM_, self.kiM_, self.omegaM_,self.phiM_,self.aiM_,self.mwl,self.depth, self.Nall, self.waveDirM_, self.vDir_, self.tanhM_)
+        __cpp_uDir(U, x,t,self.kDirM_, self.kiM_, self.omegaM_,self.phiM_,self.aiM_,self.mwl,self.depth, self.Nall, self.waveDirM_, self.vDir_, self.tanhM_)
 
     def u(self, x, t):
         """Calculates wave velocity vector (RandomWaves class)
@@ -1274,15 +1305,21 @@ class MultiSpectraRandomWaves:
         """
 
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
-        cppUL = self._cpp_u(xx,t)            
-        U[0] = cppUL[0]
-        U[1] = cppUL[1]
-        U[2] = cppUL[2]
-
+        self._cpp_u(cppU,xx,t)            
+        U[0] = cppU[0]
+        U[1] = cppU[1]
+        U[2] = cppU[2]
         return U
 
 
@@ -1500,9 +1537,9 @@ class DirectionalWaves:
         xx[2] = x[2]
         return self._cpp_eta(xx,t)
 
-    def _cpp_u(self,  x,  t):
+    def _cpp_u(self,U,  x,  t):
 
-        return __cpp_uDir(x,t,self.kDir_, self.ki_, self.omega_,self.phi_,self.ai_,self.mwl,self.depth, self.Nall, self.waveDir_, self.vDir_, self.tanh_)
+        __cpp_uDir(U, x,t,self.kDir_, self.ki_, self.omega_,self.phi_,self.ai_,self.mwl,self.depth, self.Nall, self.waveDir_, self.vDir_, self.tanh_)
 
     def u(self, x, t):
         """Calculates wave velocity vector (RandomWaves class)
@@ -1521,15 +1558,21 @@ class DirectionalWaves:
         """
 
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
-        cppUL = self._cpp_u(xx,t)            
-        U[0] = cppUL[0]
-        U[1] = cppUL[1]
-        U[2] = cppUL[2]
-
+        self._cpp_u(cppU,xx,t)            
+        U[0] = cppU[0]
+        U[1] = cppU[1]
+        U[2] = cppU[2]
         return U
        
 
@@ -1917,8 +1960,8 @@ class TimeSeries:
 
     def _cpp_etaDirect(self,x,t):
         return __cpp_etaDirect(x,self.x0_,t,self.kDir_,self.omega_,self.phi_,self.ai_,self.Nf)
-    def _cpp_uDirect(self,x,t):
-        return __cpp_uDirect(x,self.x0_,t,self.kDir_,self.ki_,self.omega_,self.phi_,self.ai_,self.mwl,self.depth,self.Nf,self.waveDir_, self.vDir_, self.tanh_)
+    def _cpp_uDirect(self,U,x,t):
+        __cpp_uDirect(U,x,self.x0_,t,self.kDir_,self.ki_,self.omega_,self.phi_,self.ai_,self.mwl,self.depth,self.Nf,self.waveDir_, self.vDir_, self.tanh_)
 
     def etaDirect(self, x, t):
 
@@ -1957,15 +2000,23 @@ class TimeSeries:
             Velocity vector as 1D array
 
         """
+
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
-        cppUL = self._cpp_uDirect(xx,t)            
-        U[0] = cppUL[0]
-        U[1] = cppUL[1]
-        U[2] = cppUL[2]
+        self._cpp_uDirect(cppU,xx,t)            
+        U[0] = cppU[0]
+        U[1] = cppU[1]
+        U[2] = cppU[2]
 
         return U
  
@@ -1990,9 +2041,9 @@ class TimeSeries:
         Nw = __cpp_findWindow(t,self.handover, self.t0,self.Twindow,self.Nwindows, self.whand_) #Nw
         
         return __cpp_etaWindow(x,self.x0_,t,self.T0_,self.kDir_,self.omega_,self.phi_,self.ai_,self.Nf,Nw)
-    def _cpp_uWindow(self,x,t):
+    def _cpp_uWindow(self,U, x,t):
         Nw = __cpp_findWindow(t,self.handover, self.t0,self.Twindow,self.Nwindows, self.whand_) #Nw
-        return __cpp_uWindow(x,self.x0_,t,self.T0_,self.kDir_,self.ki_,self.omega_,self.phi_,self.ai_,self.mwl,self.depth,self.Nf,Nw,self.waveDir_, self.vDir_, self.tanh_)
+        __cpp_uWindow(U,x,self.x0_,t,self.T0_,self.kDir_,self.ki_,self.omega_,self.phi_,self.ai_,self.mwl,self.depth,self.Nf,Nw,self.waveDir_, self.vDir_, self.tanh_)
 
     def etaWindow(self, x, t):
         """Calculates free surface elevation(Timeseries class-window method
@@ -2032,14 +2083,21 @@ class TimeSeries:
 
         """
         cython.declare(xx=cython.double[3])
+<<<<<<< HEAD
         xx[0] = x[0]
         xx[1] = x[1]
         xx[2] = x[2]
+=======
+        cython.declare(cppU=cython.double[3])
+        for ii in range(3):
+            xx[ii] = x[ii]
+            cppU[ii] = 0.
+>>>>>>> 7e4e4fc... Fixed leaking issues, removed any returned pointers, modifying velocities through passing pointers at the arguments
         U = np.zeros(3,)
-        cppUL = self._cpp_uWindow(xx,t)            
-        U[0] = cppUL[0]
-        U[1] = cppUL[1]
-        U[2] = cppUL[2]
+        self._cpp_uWindow(cppU,xx,t)            
+        U[0] = cppU[0]
+        U[1] = cppU[1]
+        U[2] = cppU[2]
 
         return U
 


### PR DESCRIPTION
The leaks are fixed. I was doing something naive: starting new pointers within the C++ scope, which turns out that it is too troublesome to deallocate. 

Now the velocity is passed as a pointer through the argument list and it is updated within the function, therefore all _cpp_u functions are treated as void.

I will do one minor optimisation yet and then hopefully we merge and resolve this Bug