### PR TITLE
removed unused ipython sphinx extensions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,8 +50,8 @@ extensions = [
 #    'sphinx.ext.viewcode',
     'sphinx.ext.linkcode',
     'sphinx.ext.napoleon',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive',
+#    'IPython.sphinxext.ipython_console_highlighting',
+#    'IPython.sphinxext.ipython_directive',
 ]
 
 napoleon_use_ivar = True


### PR DESCRIPTION
at present we're not installing ipython by default...