### PR TITLE
updated to 1.3.1, fixed circular import in MeshTools

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = proteus
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.2.0
+PROJECT_NUMBER         = 1.3.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -104,11 +104,13 @@
      style="height:1in;"> A Python toolkit for computational methods and simulation</p>
     <div class="btn-group" role="group">
       <a class="btn btn-success"
-          href="https://github.com/erdc-cm/proteus/archive/1.2.0.tar.gz">
+          href="https://github.com/erdc-cm/proteus/archive/1.3.1.tar.gz">
             <span class="glyphicon glyphicon-download"></span> Download
       </a>
       <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
       <ul class="dropdown-menu">
+        <li><a https://github.com/erdc-cm/proteus/archive/1.3.1.tar.gz">Version 1.3.1</a></li>
+        <li><a https://github.com/erdc-cm/proteus/archive/1.3.0.tar.gz">Version 1.3.0</a></li>
         <li><a https://github.com/erdc-cm/proteus/archive/1.2.0.tar.gz">Version 1.2.0</a></li>
       </ul>
     </div>

--- a/proteus/MeshTools.py
+++ b/proteus/MeshTools.py
@@ -1239,9 +1239,10 @@ class Mesh:
 
     def buildMatlabMeshDataStructures(self,meshFileBase='meshMatlab',writeToFile=True):
         """
-        build array data structures for matlab finite element mesh representation
-        and write to a file to view and play with in matlatb. The current matlab support
-        is mostly for 2d, but this will return basic arrays for 1d and 3d too
+        build array data structures for matlab finite element mesh
+        representation and write to a file to view and play with in
+        matlatb. The current matlab support is mostly for 2d, but this
+        will return basic arrays for 1d and 3d too
 
         in matlab can then print mesh with
 
@@ -1262,6 +1263,7 @@ class Mesh:
              row 1 = x coord,
              row 2 = y coord for nodes in mesh
              row 3 = z coord for nodes in mesh ...
+
         edge matrix is [2*nd+3 x num faces]
           format:
              row 1  = start vertex number
@@ -1280,10 +1282,11 @@ class Mesh:
             ...
             row nd+1 = vertex 3 global number
             row 4 = triangle subdomain number
+
          where 1,2,3 is a local counter clockwise numbering of vertices in
            triangle
 
-         """
+        """
         matlabBase = 1
         nd = self.nNodes_element-1
         p = np.zeros((nd,self.nNodes_global),'d')
@@ -6085,10 +6088,6 @@ def getMeshIntersections(mesh, toPolyhedron, endpoints):
             intersections.update(((tuple(elementIntersections[0]), tuple(elementIntersections[1])),),)
     return intersections
 
-
-from proteus import default_n as dn
-from proteus import default_p as dp
-
 class MeshOptions:
     """
     Mesh options for the domain
@@ -6101,17 +6100,17 @@ class MeshOptions:
         self.Domain = domain
         self.he = 1.
         self.use_gmsh = False
-        self.genMesh = dp.genMesh
+        self.genMesh = True
         self.outputFiles_name = 'mesh'
         self.outputFiles = {'poly': True,     
                             'ply': False,        
                             'asymptote': False,
                             'geo': False}
-        self.restrictFineSolutionToAllMeshes = dn.restrictFineSolutionToAllMeshes
-        self.parallelPartitioningType = dn.parallelPartitioningType
-        self.nLayersOfOverlapForParallel = dn.parallelPartitioningType
-        self.triangleOptions = dn.triangleOptions  # defined when setTriangleOptions called
-        self.nLevels = dn.nLevels
+        self.restrictFineSolutionToAllMeshes = False
+        self.parallelPartitioningType = MeshParallelPartitioningTypes.node
+        self.nLayersOfOverlapForParallel = 1
+        self.triangleOptions = "q30DenA" # defined when setTriangleOptions called
+        self.nLevels = 1
         if domain is not None:
             self.nd = domain.nd
             if self.nd == 2:

--- a/proteus/__init__.py
+++ b/proteus/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
 
-__version__ = '1.2.0'
+__version__ = '1.3.1'
 
 __all__ = ["Archiver",
            "Domain",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ for arg in sys.argv:
         break
 
 setup(name='proteus',
-      version='1.2.0',
+      version='1.3.1',
       description='Python tools for multiphysics modeling',
       author='Chris Kees, Matthew Farthing, et al.',
       author_email='christopher.e.kees@usace.army.mil',


### PR DESCRIPTION
@tridelat I had to hard code some defaults in the new MeshOptions structure because default_n imports MeshTools right now. 