### PR TITLE
MeshAdaptPUMI/ErrorResidualMethod: avoid dynamic arrays.

### DIFF
--- a/proteus/MeshAdaptPUMI/ErrorResidualMethod.cpp
+++ b/proteus/MeshAdaptPUMI/ErrorResidualMethod.cpp
@@ -149,8 +149,9 @@ bool isInSimplex(apf::Mesh* mesh, apf::MeshEntity* ent, apf::Vector3 pt, int dim
     c[3] = pt-vtxs[0];
   }
 
-  apf::Matrix3x3 K,Kinv;
-  apf::Vector3 F;
+  apf::Matrix3x3 K(0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
+  apf::Matrix3x3 Kinv;
+  apf::Vector3 F(0.0,0.0,0.0);
   for(int i=0;i<dim;i++){
     for(int j=0;j<dim;j++){
       K[i][j] = getDotProduct(c[i],c[j]);

--- a/proteus/MeshAdaptPUMI/ErrorResidualMethod.cpp
+++ b/proteus/MeshAdaptPUMI/ErrorResidualMethod.cpp
@@ -132,11 +132,11 @@ bool isInSimplex(apf::Mesh* mesh, apf::MeshEntity* ent, apf::Vector3 pt, int dim
   int numverts = dim+1;
   apf::Adjacent verts;
   mesh->getAdjacent(ent,0,verts);
-  apf::Vector3 vtxs[numverts];
+  apf::Vector3 vtxs[4];
   for(int i=0;i<numverts;i++){
     mesh->getPoint(verts[i],0,vtxs[i]); 
   } 
-  apf::Vector3 c[numverts];
+  apf::Vector3 c[4];
   if(dim==2){
     c[0] = vtxs[1]-vtxs[0];
     c[1] = vtxs[2]-vtxs[0];


### PR DESCRIPTION
Set the array length for simplex iteration to 4, its maximum value.