### PR TITLE
make sure Dirichlet values are set for Velocity at atmospheric bdry

### DIFF
--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -169,18 +169,21 @@ class BC_RANS(BC_Base):
             orientation = self._b_or
         self.reset()
         self.p_dirichlet.setConstantBC(0.)
-        if self._b_or[0] == 1. or self._b_or[0] == -1.:
-            self.u_dirichlet.setConstantBC(0.)
-        else:
-            self.u_dirichlet.resetBC()
-        if self._b_or[1] == 1. or self._b_or[1] == -1.:
-            self.v_dirichlet.setConstantBC(0.)
-        else:
-            self.v_dirichlet.resetBC()
-        if self._b_or[2] == 1. or self._b_or[2] == -1.:
-            self.w_dirichlet.setConstantBC(0.)
-        else:
-            self.w_dirichlet.resetBC()
+        self.u_dirichlet.setConstantBC(0.)
+        self.v_dirichlet.setConstantBC(0.)
+        self.w_dirichlet.setConstantBC(0.)
+        # if self._b_or[0] == 1. or self._b_or[0] == -1.:
+        #     self.u_dirichlet.setConstantBC(0.)
+        # else:
+        #     self.u_dirichlet.resetBC()
+        # if self._b_or[1] == 1. or self._b_or[1] == -1.:
+        #     self.v_dirichlet.setConstantBC(0.)
+        # else:
+        #     self.v_dirichlet.resetBC()
+        # if self._b_or[2] == 1. or self._b_or[2] == -1.:
+        #     self.w_dirichlet.setConstantBC(0.)
+        # else:
+        #     self.w_dirichlet.resetBC()
         self.vof_dirichlet.setConstantBC(vof_air)  # air
         self.u_diffusive.setConstantBC(0.)
         self.v_diffusive.setConstantBC(0.)

--- a/proteus/mprans/BoundaryConditions.py
+++ b/proteus/mprans/BoundaryConditions.py
@@ -172,22 +172,13 @@ class BC_RANS(BC_Base):
         self.u_dirichlet.setConstantBC(0.)
         self.v_dirichlet.setConstantBC(0.)
         self.w_dirichlet.setConstantBC(0.)
-        # if self._b_or[0] == 1. or self._b_or[0] == -1.:
-        #     self.u_dirichlet.setConstantBC(0.)
-        # else:
-        #     self.u_dirichlet.resetBC()
-        # if self._b_or[1] == 1. or self._b_or[1] == -1.:
-        #     self.v_dirichlet.setConstantBC(0.)
-        # else:
-        #     self.v_dirichlet.resetBC()
-        # if self._b_or[2] == 1. or self._b_or[2] == -1.:
-        #     self.w_dirichlet.setConstantBC(0.)
-        # else:
-        #     self.w_dirichlet.resetBC()
         self.vof_dirichlet.setConstantBC(vof_air)  # air
-        self.u_diffusive.setConstantBC(0.)
-        self.v_diffusive.setConstantBC(0.)
-        self.w_diffusive.setConstantBC(0.)
+        if self._b_or[0] == 1. or self._b_or[0] == -1.:
+            self.u_diffusive.setConstantBC(0.)
+        if self._b_or[1] == 1. or self._b_or[1] == -1.:
+            self.v_diffusive.setConstantBC(0.)
+        if self._b_or[2] == 1. or self._b_or[2] == -1.:
+            self.w_diffusive.setConstantBC(0.)
         self.k_diffusive.setConstantBC(0.)
         self.dissipation_diffusive.setConstantBC(0.)
 


### PR DESCRIPTION
We need to make sure there's a Dirichlet value for all components of velocity if the boundary is open. To allow tangential components to slip you set the DiffusiveFlux to zero for those components. @tridelat this seems to fix the nonlinear solver convergence issues I've found in the updated wavetanks from @lmaurel and seen by @cdmoore. 