### PR TITLE
Better error/help message for gmsh2tetgen

### DIFF
--- a/scripts/gmsh2tetgen.f
+++ b/scripts/gmsh2tetgen.f
@@ -57,7 +57,13 @@
 	    call getarg(5,perm_z_string)           
 	    read (perm_z_string,*) perm(3)  
 	  else
-	    write(*,*) 'Wrong input'
+	    write(*,*) 'Input should be: (.mesh) (length scale, optional) '// &
+        '(x permutation, optional) (y permutation, optional) '// &
+        '(z permutation, optional)'
+      write(*,*) 'If using the optional permutation input, all three '//&
+        'permutations must be specified. The permutations dictate '//&
+        'how vertices are written out in the resulting mesh. Default '//&
+        'is [1,2,3]'
 	    stop
 	  endif    
     

--- a/scripts/gmsh2tetgen.f
+++ b/scripts/gmsh2tetgen.f
@@ -60,6 +60,8 @@
 	    write(*,*) 'Input should be: (.mesh) (length scale, optional) '// &
         '(x permutation, optional) (y permutation, optional) '// &
         '(z permutation, optional)'
+      write(*,*) 'The length scale scales the vertex coordinates '// &
+        'in each dimension in the resulting mesh'
       write(*,*) 'If using the optional permutation input, all three '//&
         'permutations must be specified. The permutations dictate '//&
         'how vertices are written out in the resulting mesh. Default '//&


### PR DESCRIPTION
This PR adds some more informative error/help strings to those who use the gmsh2tetgen utility by indicating the potential inputs and briefly describing what those inputs do.