### PR TITLE
Use member initializer list for nSpace2

### DIFF
--- a/proteus/mprans/RANS3PF2D.h
+++ b/proteus/mprans/RANS3PF2D.h
@@ -407,9 +407,10 @@ namespace proteus
   public:
     cppHsuSedStress<2> closure;
     const int nDOF_test_X_trial_element,
-      nSpace2=4;
+      nSpace2;
     CompKernelType ck;
     cppRANS3PF2D():
+      nSpace2(4),
       closure(150.0,
               0.0,
               0.0102,


### PR DESCRIPTION
Compilation of object file proteus/mprans/RANS3PF.o fails with the following
error on an old compiler:
```bash
In file included from proteus/mprans/RANS3PF.cpp:452:
proteus/mprans/RANS3PF2D.h:410: error: ISO C++ forbids initialization of member ‘nSpace2’
proteus/mprans/RANS3PF2D.h:410: error: making ‘nSpace2’ static error: command
'gcc' failed with exit status 1
```
This patch fixes the issue by moving the initialization of variable nSpace2 to
the constructor using initializer list.