### PR TITLE
SCOREC 2D Reconstruct Part 1 of 2: 2D Error Estimate and Adapt

### DIFF
--- a/proteus/Domain.py
+++ b/proteus/Domain.py
@@ -874,6 +874,7 @@ class PUMIDomain(D_base):
   def __init__(self, name="PUMIDomain", dim=3):
       D_base.__init__(self,dim,name)
       self.faceList=[]
+      self.regList=[]
       self.PUMIMesh=None
       #
       #it would be useful to define a dictionary mapping strings to faces

--- a/proteus/MeshAdaptPUMI/MeshAdaptPUMI.h
+++ b/proteus/MeshAdaptPUMI/MeshAdaptPUMI.h
@@ -26,7 +26,7 @@ class MeshAdaptPUMIDrvr{
   //Functions to construct proteus mesh data structures
   int constructFromSerialPUMIMesh(Mesh& mesh);
   int constructFromParallelPUMIMesh(Mesh& mesh, Mesh& subdomain_mesh);
-  int updateMaterialArrays(Mesh& mesh, int bdryID, int GeomTag);
+  int updateMaterialArrays(Mesh& mesh,int dim, int bdryID, int GeomTag);
   void numberLocally();
   int localNumber(apf::MeshEntity* e);
   int dumpMesh(Mesh& mesh);

--- a/proteus/MeshAdaptPUMI/MeshAdaptPUMI.pyx
+++ b/proteus/MeshAdaptPUMI/MeshAdaptPUMI.pyx
@@ -24,7 +24,7 @@ cdef extern from "MeshAdaptPUMI/MeshAdaptPUMI.h":
         int getSimmetrixBC()
         int constructFromSerialPUMIMesh(Mesh&)
         int constructFromParallelPUMIMesh(Mesh&, Mesh&)
-        int updateMaterialArrays(Mesh&, int, int)
+        int updateMaterialArrays(Mesh&,int, int, int)
         int transferFieldToPUMI(char*, double*, int, int)
         int transferFieldToProteus(char*, double*, int, int)
         int transferPropertiesToPUMI(double*, double*,double*)
@@ -63,9 +63,9 @@ cdef class MeshAdaptPUMI:
         cdef CMesh* cmesh_ptr = <CMesh*>cmesh
         cdef CMesh* subdomain_cmesh_ptr = <CMesh*>subdomain_cmesh
         return self.thisptr.constructFromParallelPUMIMesh(cmesh_ptr.mesh, subdomain_cmesh_ptr.mesh)
-    def updateMaterialArrays(self, cmesh, bdryId, geomTag):
+    def updateMaterialArrays(self, cmesh, dim,bdryId, geomTag):
         cdef CMesh* cmesh_ptr = <CMesh*>cmesh
-        return self.thisptr.updateMaterialArrays(cmesh_ptr.mesh, bdryId, geomTag)
+        return self.thisptr.updateMaterialArrays(cmesh_ptr.mesh,dim, bdryId, geomTag)
     def transferFieldToPUMI(self, name, np.ndarray[np.double_t,ndim=2,mode="c"] inArray):
         inArray = np.ascontiguousarray(inArray)
         return self.thisptr.transferFieldToPUMI(name, &inArray[0,0], inArray.shape[1], inArray.shape[0])

--- a/proteus/MeshAdaptPUMI/MeshConverter.cpp
+++ b/proteus/MeshAdaptPUMI/MeshConverter.cpp
@@ -214,7 +214,6 @@ int MeshAdaptPUMIDrvr::constructBoundaries(Mesh& mesh)
     //left and right regions are shared by this face we are currntly on
     int leftRgnID = RgnID[0]; int leftLocalBoundaryNumber = localBoundaryNumber[0];
     int rightRgnID = RgnID[1]; int rightLocalBoundaryNumber = localBoundaryNumber[1];
-
     /*left region is always there, so either rightRgnID will have
       an actual ID if this face is shared, or will contain -1
       if it is an exterior face */
@@ -389,25 +388,36 @@ int MeshAdaptPUMIDrvr::constructMaterialArrays(Mesh& mesh)
  * array slot.
  */
 int MeshAdaptPUMIDrvr::updateMaterialArrays(Mesh& mesh,
+    int dim,
     int proteus_material,
     int scorec_tag)
 {
-  int dim = m->getDimension();
-  apf::ModelEntity* geomEnt = m->findModelEntity(dim - 1, scorec_tag);
-  apf::MeshIterator* it = m->begin(dim - 1);
+  //int dim = m->getDimension();
+  apf::ModelEntity* geomEnt = m->findModelEntity(dim, scorec_tag);
+  apf::MeshIterator* it = m->begin(dim);
   apf::MeshEntity* f;
-  while ((f = m->iterate(it))) {
-    if (m->toModel(f) == geomEnt) {
+  if(dim==m->getDimension()){
+    while ((f = m->iterate(it))) {
+     if (m->toModel(f) == geomEnt) {
       int i = localNumber(f);
-      mesh.elementBoundaryMaterialTypes[i] = proteus_material;
+      mesh.elementMaterialTypes[i] = proteus_material;
+     }
+    }
+  }
+  else{
+    while ((f = m->iterate(it))) {
+      if (m->toModel(f) == geomEnt) {
+        int i = localNumber(f);
+        mesh.elementBoundaryMaterialTypes[i] = proteus_material;
+      }
+    }
+    apf::DynamicArray<apf::Node> nodes;
+    apf::getNodesOnClosure(m, geomEnt, nodes);
+    for (size_t i = 0; i < nodes.getSize(); ++i) {
+      int vtxId = localNumber(nodes[i].entity);
+      mesh.nodeMaterialTypes[vtxId] = proteus_material;
     }
   }
   m->end(it);
-  apf::DynamicArray<apf::Node> nodes;
-  apf::getNodesOnClosure(m, geomEnt, nodes);
-  for (size_t i = 0; i < nodes.getSize(); ++i) {
-    int vtxId = localNumber(nodes[i].entity);
-    mesh.nodeMaterialTypes[vtxId] = proteus_material;
-  }
   return 0;
 }

--- a/proteus/MeshAdaptPUMI/MeshConverter.cpp
+++ b/proteus/MeshAdaptPUMI/MeshConverter.cpp
@@ -392,7 +392,6 @@ int MeshAdaptPUMIDrvr::updateMaterialArrays(Mesh& mesh,
     int proteus_material,
     int scorec_tag)
 {
-  //int dim = m->getDimension();
   apf::ModelEntity* geomEnt = m->findModelEntity(dim, scorec_tag);
   apf::MeshIterator* it = m->begin(dim);
   apf::MeshEntity* f;

--- a/proteus/MeshAdaptPUMI/ParallelMeshConverter.cpp
+++ b/proteus/MeshAdaptPUMI/ParallelMeshConverter.cpp
@@ -30,10 +30,11 @@ int MeshAdaptPUMIDrvr::constructFromParallelPUMIMesh(Mesh& mesh, Mesh& subdomain
   if (!PCU_Comm_Self())
     std::cerr << "Constructing parallel proteus mesh\n"; 
   
-  int numGlobElem = countTotal(m, 3);
+  int dim = m->getDimension();
+  int numGlobElem = countTotal(m, dim);
   mesh.nElements_global = numGlobElem;
 
-  int numLocElem = m->count(3);
+  int numLocElem = m->count(dim);
   mesh.subdomainp->nElements_global = numLocElem;
 
   int numGlobNodes = countTotal(m, 0);
@@ -43,21 +44,31 @@ int MeshAdaptPUMIDrvr::constructFromParallelPUMIMesh(Mesh& mesh, Mesh& subdomain
   mesh.subdomainp->nNodes_global = numLocNodes;
 
   int numGlobFaces = countTotal(m, 2);
-  mesh.nElementBoundaries_global = numGlobFaces;
-
   int numLocFaces = m->count(2);
-  mesh.subdomainp->nElementBoundaries_global = numLocFaces;
 
   int numGlobEdges = countTotal(m, 1);
   mesh.nEdges_global = numGlobEdges;
 
   int numLocEdges = m->count(1);
   mesh.subdomainp->nEdges_global = numLocEdges;
-//nNodes_element for now is constant for the entire mesh, Ask proteus about using mixed meshes
-//therefore currently this code only supports tet meshes
-  mesh.subdomainp->nNodes_element = 4; //hardcode: for tets, number of nodes per element
-  mesh.subdomainp->nNodes_elementBoundary = 3; //hardcode: for tets, looks like number of nodes of a face
-  mesh.subdomainp->nElementBoundaries_element = 4; //hardcode: for tets, looks like number of faces/element
+
+  if(dim==3){ 
+    mesh.nElementBoundaries_global = numGlobFaces;
+    mesh.subdomainp->nElementBoundaries_global = numLocFaces;
+    //nNodes_element for now is constant for the entire mesh, Ask proteus about using mixed meshes
+    //therefore currently this code only supports tet meshes
+    mesh.subdomainp->nNodes_element = 4; //hardcode: for tets, number of nodes per element
+    mesh.subdomainp->nNodes_elementBoundary = 3; //hardcode: for tets, looks like number of nodes of a face
+    mesh.subdomainp->nElementBoundaries_element = 4; //hardcode: for tets, looks like number of faces/element
+  }
+  else if(dim==2){
+    mesh.nElementBoundaries_global = numGlobEdges;
+    mesh.subdomainp->nElementBoundaries_global = numLocEdges;
+    mesh.subdomainp->nNodes_element = 3; //hardcode: for tets, number of nodes per element
+    mesh.subdomainp->nNodes_elementBoundary = 2; //hardcode: for tets, looks like number of nodes of a face
+    mesh.subdomainp->nElementBoundaries_element = 3; //hardcode: for tets, looks like number of faces/element
+  }
+
   
 #ifdef MESH_INFO
   for (int i = 0; i < PCU_Comm_Peers(); ++i) {
@@ -109,40 +120,76 @@ int MeshAdaptPUMIDrvr::constructGlobalNumbering(Mesh &mesh)
   mesh.edgeOffsets_subdomain_owned = new int[comm_size+1];
   mesh.nodeOffsets_subdomain_owned = new int[comm_size+1];
 
-  for (int dim = 0; dim <= m->getDimension(); ++dim) {
+  if(m->getDimension()==3){
+    for (int dim = 0; dim <= m->getDimension(); ++dim) {
 
-    int nLocalOwned = apf::countOwned(m, dim);
-    int localOffset = nLocalOwned;
-    PCU_Exscan_Ints(&localOffset, 1);
+      int nLocalOwned = apf::countOwned(m, dim);
+      int localOffset = nLocalOwned;
+      PCU_Exscan_Ints(&localOffset, 1);
 
-    int* allOffsets;
-    if(dim==3){
-      allOffsets = mesh.elementOffsets_subdomain_owned;
-    }
-    if(dim==2){
-      allOffsets = mesh.elementBoundaryOffsets_subdomain_owned;
-    }
-    if(dim==1){
-      allOffsets = mesh.edgeOffsets_subdomain_owned;
-    }
-    if(dim==0){
-      allOffsets = mesh.nodeOffsets_subdomain_owned;
-    }
+      int* allOffsets;
+      if(dim==3){
+        allOffsets = mesh.elementOffsets_subdomain_owned;
+      }
+      if(dim==2){
+        allOffsets = mesh.elementBoundaryOffsets_subdomain_owned;
+      }
+      if(dim==1){
+        allOffsets = mesh.edgeOffsets_subdomain_owned;
+      }
+      if(dim==0){
+        allOffsets = mesh.nodeOffsets_subdomain_owned;
+      }
 
-    /* one of the many reasons N^2 algorithms are bad */
-    MPI_Allgather(&localOffset, 1, MPI_INT,
-                  allOffsets, 1, MPI_INT, MPI_COMM_WORLD);
-    allOffsets[PCU_Comm_Peers()] = countTotal(m, dim);
+      /* one of the many reasons N^2 algorithms are bad */
+      MPI_Allgather(&localOffset, 1, MPI_INT,
+                    allOffsets, 1, MPI_INT, MPI_COMM_WORLD);
+      allOffsets[PCU_Comm_Peers()] = countTotal(m, dim);
+  
+      std::stringstream ss;
+      ss << "proteus_global_";
+      ss << dim;
+      std::string name = ss.str();
+      /* this algorithm does global numbering properly,
+        without O(#procs) runtime */
+      global[dim] = apf::makeGlobal(apf::numberOwnedDimension(m, name.c_str(), dim));
+      apf::synchronize(global[dim]);
+    } //loop on entity dimensions
+  }
+  else if(m->getDimension()==2){
+    for (int dim = 0; dim <= m->getDimension(); ++dim) {
 
-    std::stringstream ss;
-    ss << "proteus_global_";
-    ss << dim;
-    std::string name = ss.str();
-    /* this algorithm does global numbering properly,
-       without O(#procs) runtime */
-    global[dim] = apf::makeGlobal(apf::numberOwnedDimension(m, name.c_str(), dim));
-    apf::synchronize(global[dim]);
-  } //loop on entity dimensions
+      int nLocalOwned = apf::countOwned(m, dim);
+      int localOffset = nLocalOwned;
+      PCU_Exscan_Ints(&localOffset, 1);
+
+      int* allOffsets;
+      if(dim==2){
+        allOffsets = mesh.elementOffsets_subdomain_owned;
+      }
+      if(dim==1){
+        allOffsets = mesh.elementBoundaryOffsets_subdomain_owned;
+      }
+      if(dim==0){
+        allOffsets = mesh.nodeOffsets_subdomain_owned;
+      }
+
+      /* one of the many reasons N^2 algorithms are bad */
+      MPI_Allgather(&localOffset, 1, MPI_INT,
+                    allOffsets, 1, MPI_INT, MPI_COMM_WORLD);
+      allOffsets[PCU_Comm_Peers()] = countTotal(m, dim);
+      std::stringstream ss;
+      ss << "proteus_global_";
+      ss << dim;
+      std::string name = ss.str();
+      /* this algorithm does global numbering properly,
+        without O(#procs) runtime */
+      global[dim] = apf::makeGlobal(apf::numberOwnedDimension(m, name.c_str(), dim));
+      apf::synchronize(global[dim]);
+    } //loop on entity dimensions
+    mesh.edgeOffsets_subdomain_owned = mesh.elementBoundaryOffsets_subdomain_owned;
+  }
+
 
   return 0; 
 }
@@ -154,21 +201,41 @@ int MeshAdaptPUMIDrvr::constructGlobalStructures(Mesh &mesh)
   mesh.nodeNumbering_subdomain2global = new int[mesh.subdomainp->nNodes_global];
   mesh.edgeNumbering_subdomain2global = new int[mesh.subdomainp->nEdges_global];
   
-  for (int d = 0; d <= m->getDimension(); ++d) {
-    int* temp_subdomain2global;
-    if(d==3) temp_subdomain2global = mesh.elementNumbering_subdomain2global;
-    if(d==2) temp_subdomain2global = mesh.elementBoundaryNumbering_subdomain2global;
-    if(d==1) temp_subdomain2global = mesh.edgeNumbering_subdomain2global;
-    if(d==0) temp_subdomain2global = mesh.nodeNumbering_subdomain2global;
+  if(m->getDimension()==3){
+    for (int d = 0; d <= m->getDimension(); ++d) {
+     int* temp_subdomain2global;
+     if(d==3) temp_subdomain2global = mesh.elementNumbering_subdomain2global;
+     if(d==2) temp_subdomain2global = mesh.elementBoundaryNumbering_subdomain2global;
+     if(d==1) temp_subdomain2global = mesh.edgeNumbering_subdomain2global;
+     if(d==0) temp_subdomain2global = mesh.nodeNumbering_subdomain2global;
 
-    apf::MeshIterator* it = m->begin(d);
-    apf::MeshEntity* e;
-    while ((e = m->iterate(it))) {
-      int i = localNumber(e);
-      temp_subdomain2global[i] = apf::getNumber(global[d], apf::Node(e, 0));
-    }
-    m->end(it);
-    apf::destroyGlobalNumbering(global[d]);
+     apf::MeshIterator* it = m->begin(d);
+     apf::MeshEntity* e;
+     while ((e = m->iterate(it))) {
+       int i = localNumber(e);
+       temp_subdomain2global[i] = apf::getNumber(global[d], apf::Node(e, 0));
+     }
+     m->end(it);
+     apf::destroyGlobalNumbering(global[d]);
+   }
+  }
+  else if(m->getDimension()==2){
+    for (int d = 0; d <= m->getDimension(); ++d) {
+     int* temp_subdomain2global;
+     int* temp_subdomain2global2; //just for the edge and element boundary array overlap
+     if(d==2) temp_subdomain2global = mesh.elementNumbering_subdomain2global;
+     if(d==1) temp_subdomain2global = mesh.elementBoundaryNumbering_subdomain2global;
+     if(d==0) temp_subdomain2global = mesh.nodeNumbering_subdomain2global;
+     apf::MeshIterator* it = m->begin(d);
+     apf::MeshEntity* e;
+     while ((e = m->iterate(it))) {
+       int i = localNumber(e);
+       temp_subdomain2global[i] = apf::getNumber(global[d], apf::Node(e, 0));
+     }
+     m->end(it);
+     apf::destroyGlobalNumbering(global[d]);
+   }
+   mesh.edgeNumbering_subdomain2global=mesh.elementBoundaryNumbering_subdomain2global;
   }
 
   return 0;

--- a/proteus/MeshTools.py
+++ b/proteus/MeshTools.py
@@ -1526,7 +1526,7 @@ class Mesh:
             gnuplot.flush()
         raw_input('Please press return to continue... \n')
 
-    def convertFromPUMI(self, PUMIMesh, faceList, parallel=False, dim=3):
+    def convertFromPUMI(self, PUMIMesh, faceList,regList, parallel=False, dim=3):
         import cmeshTools
         import MeshAdaptPUMI
         import flcbdfWrappers
@@ -1541,8 +1541,11 @@ class Mesh:
               self.subdomainMesh.cmesh)
           for i in range(len(faceList)):
             for j in range(len(faceList[i])):
-              PUMIMesh.updateMaterialArrays(self.subdomainMesh.cmesh, i+1,
+              PUMIMesh.updateMaterialArrays(self.subdomainMesh.cmesh,(dim-1), i+1,
                   faceList[i][j])
+          for i in range(len(regList)):
+            for j in range(len(regList[i])):
+              PUMIMesh.updateMaterialArrays(self.subdomainMesh.cmesh,dim, i+1, regList[i][j])
           if dim == 3:
             cmeshTools.allocateGeometricInfo_tetrahedron(self.subdomainMesh.cmesh)
             cmeshTools.computeGeometricInfo_tetrahedron(self.subdomainMesh.cmesh)
@@ -1589,7 +1592,10 @@ class Mesh:
           PUMIMesh.constructFromSerialPUMIMesh(self.cmesh)
           for i in range(len(faceList)):
             for j in range(len(faceList[i])):
-              PUMIMesh.updateMaterialArrays(self.cmesh, i+1, faceList[i][j])
+              PUMIMesh.updateMaterialArrays(self.cmesh,(dim-1), i+1, faceList[i][j])
+          for i in range(len(regList)):
+            for j in range(len(regList[i])):
+              PUMIMesh.updateMaterialArrays(self.cmesh,dim, i+1, regList[i][j])
           if dim == 3:
             cmeshTools.allocateGeometricInfo_tetrahedron(self.cmesh)
             cmeshTools.computeGeometricInfo_tetrahedron(self.cmesh)
@@ -4712,6 +4718,14 @@ class MultilevelTriangularMesh(MultilevelMesh):
                 self.meshList[l].subdomainMesh = self.meshList[l]
                 logEvent(self.meshList[-1].meshInfo())
             self.buildArrayLists()
+    def generatePartitionedMeshFromPUMI(self,mesh0,refinementLevels,nLayersOfOverlap=1):
+        import cmeshTools
+        self.meshList = []
+        self.meshList.append(mesh0)
+        self.cmultilevelMesh = cmeshTools.CMultilevelMesh(self.meshList[0].cmesh,refinementLevels)
+        self.buildFromC(self.cmultilevelMesh)
+        self.elementParents = None
+        self.elementChildren=[]
 
     def refine(self):
         self.meshList.append(TriangularMesh())

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -783,6 +783,7 @@ class NS_base:  # (HasTraits):
           mesh = MeshTools.TriangularMesh()
         mesh.convertFromPUMI(p0.domain.PUMIMesh,
                              p0.domain.faceList,
+                             p0.domain.regList,
                              parallel = self.comm.size() > 1,
                              dim = p0.domain.nd)
         logEvent("Generating %i-level mesh from PUMI mesh" % (n0.nLevels,))

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -344,6 +344,7 @@ class NS_base:  # (HasTraits):
                   mesh = MeshTools.TriangularMesh()
                 logEvent("Converting PUMI mesh to Proteus")
                 mesh.convertFromPUMI(p.domain.PUMIMesh, p.domain.faceList,
+                    p.domain.regList,
                     parallel = comm.size() > 1, dim = p.domain.nd)
                 if p.domain.nd == 3:
                   mlMesh = MeshTools.MultilevelTetrahedralMesh(

--- a/proteus/mprans/SpatialTools.py
+++ b/proteus/mprans/SpatialTools.py
@@ -2270,7 +2270,8 @@ def assembleDomain(domain):
     _assembleGeometry(domain, BC_class=bc.BC_RANS)
     domain.bc[0].setNonMaterial()  # set BC for boundary between processors
     assembleAuxiliaryVariables(domain)
-    _generateMesh(domain)
+    if(domain.name != "PUMIDomain"):
+      _generateMesh(domain)
 
 
 def assembleAuxiliaryVariables(domain):

--- a/proteus/tests/MeshAdaptPUMI/Rectangle.dmg
+++ b/proteus/tests/MeshAdaptPUMI/Rectangle.dmg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0a0bdf5fc431227b6aa2cd68875e6323cb959d1831774d7c315a3133505fafa
+size 103

--- a/proteus/tests/MeshAdaptPUMI/Rectangle0.smb
+++ b/proteus/tests/MeshAdaptPUMI/Rectangle0.smb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:330bc9d434053b730f355824103eb1d470287774c56531c90a761becc209050a
+size 635

--- a/proteus/tests/MeshAdaptPUMI/Rectangle1.smb
+++ b/proteus/tests/MeshAdaptPUMI/Rectangle1.smb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50205de59ff0ab942799aa16c936e10cbbb659e702d6c5a1ad482a244842b8bc
+size 635

--- a/proteus/tests/MeshAdaptPUMI/TwoQuads.dmg
+++ b/proteus/tests/MeshAdaptPUMI/TwoQuads.dmg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bc072d31dc9ed93ea016f7b49519a424507aadb2c47e25942f8aeae480b25dc
+size 148

--- a/proteus/tests/MeshAdaptPUMI/TwoQuads.msh
+++ b/proteus/tests/MeshAdaptPUMI/TwoQuads.msh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e6c030b997b5f34ead54c315ede6dd21b94359279078afbf7fb4af9c928904a
-size 519

--- a/proteus/tests/MeshAdaptPUMI/TwoQuads.msh
+++ b/proteus/tests/MeshAdaptPUMI/TwoQuads.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e6c030b997b5f34ead54c315ede6dd21b94359279078afbf7fb4af9c928904a
+size 519

--- a/proteus/tests/MeshAdaptPUMI/TwoQuads0.smb
+++ b/proteus/tests/MeshAdaptPUMI/TwoQuads0.smb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f83073b2c9908d7b1dfe6c1b75e53ce12614ea6a01e5c0b50af6e82442004c8e
+size 891

--- a/proteus/tests/MeshAdaptPUMI/test_gmshCheck.py
+++ b/proteus/tests/MeshAdaptPUMI/test_gmshCheck.py
@@ -26,7 +26,7 @@ def test_gmshLoadAndAdapt(verbose=0):
     comm = Comm.init()
 
     nElements_initial = mesh.nElements_global
-    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, parallel = comm.size() > 1, dim = domain.nd)
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList,domain.regList, parallel = comm.size() > 1, dim = domain.nd)
 
     domain.PUMIMesh.transferFieldToPUMI("coordinates",mesh.nodeArray)
 
@@ -68,6 +68,7 @@ def test_gmshLoadAndAdapt(verbose=0):
     mesh = MeshTools.TetrahedralMesh()
     mesh.convertFromPUMI(domain.PUMIMesh,
                      domain.faceList,
+                     domain.regList,
                      parallel = comm.size() > 1,
                      dim = domain.nd)
     nElements_final = mesh.nElements_global
@@ -89,7 +90,7 @@ def test_2DgmshLoadAndAdapt(verbose=0):
     comm = Comm.init()
 
     nElements_initial = mesh.nElements_global
-    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, parallel = comm.size() > 1, dim = domain.nd)
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList,domain.regList, parallel = comm.size() > 1, dim = domain.nd)
 
     domain.PUMIMesh.transferFieldToPUMI("coordinates",mesh.nodeArray)
 
@@ -131,6 +132,7 @@ def test_2DgmshLoadAndAdapt(verbose=0):
     mesh = MeshTools.TriangularMesh()
     mesh.convertFromPUMI(domain.PUMIMesh,
                      domain.faceList,
+                     domain.regList,
                      parallel = comm.size() > 1,
                      dim = domain.nd)
     nElements_final = mesh.nElements_global

--- a/proteus/tests/MeshAdaptPUMI/test_gmshCheck.py
+++ b/proteus/tests/MeshAdaptPUMI/test_gmshCheck.py
@@ -138,7 +138,26 @@ def test_2DgmshLoadAndAdapt(verbose=0):
     nElements_final = mesh.nElements_global
     ok(nElements_final>nElements_initial)
 
+def test_2DmultiRegion(verbose=0):
+    """Test for loading gmsh mesh through PUMI with multiple-regions"""
+    testDir=os.path.dirname(os.path.abspath(__file__))
+    Model=testDir + '/TwoQuads.dmg'
+    Mesh=testDir + '/TwoQuads.smb'
+    domain = Domain.PUMIDomain(dim=2) #initialize the domain
+    domain.PUMIMesh=MeshAdaptPUMI.MeshAdaptPUMI()
+    domain.PUMIMesh.loadModelAndMesh(Model, Mesh)
+    domain.faceList=[[14],[12],[11],[13],[15],[16]]
+    domain.regList=[[41],[42]]
+
+    mesh = MeshTools.TriangularMesh()
+    mesh.cmesh = cmeshTools.CMesh()
+    comm = Comm.init()
+
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList,domain.regList, parallel = comm.size() > 1, dim = domain.nd)
+    ok(mesh.elementMaterialTypes[0]==1)
+    ok(mesh.elementMaterialTypes[-1]==2)
+
 if __name__ == '__main__':
     import nose
-    nose.main(defaultTest='test_gmshCheck:test_gmshLoadAndAdapt,test_gmshCheck:test_2DgmshLoadAndAdapt')
+    nose.main(defaultTest='test_gmshCheck:test_gmshLoadAndAdapt,test_gmshCheck:test_2DgmshLoadAndAdapt,test_gmshCheck:test_2DmultiRegion')
 

--- a/proteus/tests/MeshAdaptPUMI/test_parallelMeshLoad.py
+++ b/proteus/tests/MeshAdaptPUMI/test_parallelMeshLoad.py
@@ -23,7 +23,7 @@ def test_parallelLoadPUMI(verbose=0):
     domain.PUMIMesh.loadModelAndMesh(Model, Mesh)
     mesh = MeshTools.TetrahedralMesh()
     mesh.cmesh = cmeshTools.CMesh()
-    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, parallel = comm.size() > 1, dim = domain.nd)
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, domain.regList,parallel = comm.size() > 1, dim = domain.nd)
     eq(mesh.nElements_global,8148)
     eq(mesh.nNodes_global,1880)
     eq(mesh.nEdges_global,11001)

--- a/proteus/tests/MeshAdaptPUMI/test_parallelMeshLoad.py
+++ b/proteus/tests/MeshAdaptPUMI/test_parallelMeshLoad.py
@@ -10,9 +10,11 @@ import os
 from petsc4py import PETSc
 import pytest
 
+#Run these tests with `mpirun -n 2 py.test --boxed test_parallelMeshLoad.py`
+
 @pytest.mark.skip(reason="need to run in parallel")
-def test_parallelLoadPUMI(verbose=0):
-    """Test to load parallel PUMI model and mesh"""
+def test_3DparallelLoadPUMI(verbose=0):
+    """Test to load 3D parallel PUMI model and mesh"""
     comm = Comm.init()
     eq(comm.size(),2)
     testDir=os.path.dirname(os.path.abspath(__file__))
@@ -36,8 +38,27 @@ def test_parallelLoadPUMI(verbose=0):
     #    eq(mesh.nEdges_owned,8729)
     #    eq(mesh.nElementBoundaries_owned,5648)
 
+@pytest.mark.skip(reason="need to run in parallel")
+def test_2DparallelLoadPUMI(verbose=0):
+    """Test to load 2D parallel PUMI model and mesh"""
+    comm = Comm.init()
+    eq(comm.size(),2)
+    testDir=os.path.dirname(os.path.abspath(__file__))
+    domain = Domain.PUMIDomain(dim=2)
+    Model=testDir+ '/Rectangle.dmg'
+    Mesh=testDir + '/Rectangle.smb'
+    domain.PUMIMesh=MeshAdaptPUMI.MeshAdaptPUMI()
+    domain.PUMIMesh.loadModelAndMesh(Model, Mesh)
+    mesh = MeshTools.TriangularMesh()
+    mesh.cmesh = cmeshTools.CMesh()
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, domain.regList,parallel = comm.size() > 1, dim = domain.nd)
+    eq(mesh.nElements_global,8)
+    eq(mesh.nNodes_global,10)
+    eq(mesh.nEdges_global,17)
+    eq(mesh.nElementBoundaries_global,17)
+
 if __name__ == '__main__':
     import nose
-    nose.main(defaultTest='test_meshLoad:test_parallelLoadPUMI')
+    nose.main(defaultTest='test_meshLoad:test_3DparallelLoadPUMI,test_meshLoad:test_2DparallelLoadPUMI')
 
 

--- a/proteus/tests/MeshAdaptPUMI/test_poiseuilleError.py
+++ b/proteus/tests/MeshAdaptPUMI/test_poiseuilleError.py
@@ -29,7 +29,7 @@ def test_poiseuilleError(verbose=0):
     comm = Comm.init()
 
     nElements_initial = mesh.nElements_global
-    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, parallel = comm.size() > 1, dim = domain.nd)
+    mesh.convertFromPUMI(domain.PUMIMesh, domain.faceList, domain.regList,parallel = comm.size() > 1, dim = domain.nd)
 
     domain.PUMIMesh.transferFieldToPUMI("coordinates",mesh.nodeArray)
 

--- a/setup.py
+++ b/setup.py
@@ -433,7 +433,12 @@ setup(name='proteus',
                     'proteus/tests/MeshAdaptPUMI/cube.dmg',
                     'proteus/tests/MeshAdaptPUMI/Couette.null',
                     'proteus/tests/MeshAdaptPUMI/Couette.msh',
-                    'proteus/tests/MeshAdaptPUMI/Couette2D.msh'])
+                    'proteus/tests/MeshAdaptPUMI/Couette2D.msh',
+                    'proteus/tests/MeshAdaptPUMI/Rectangle0.smb',
+                    'proteus/tests/MeshAdaptPUMI/Rectangle1.smb',
+                    'proteus/tests/MeshAdaptPUMI/Rectangle.dmg',
+                    'proteus/tests/MeshAdaptPUMI/TwoQuads0.smb',
+                    'proteus/tests/MeshAdaptPUMI/TwoQuads.dmg'])
       ],
       scripts = ['scripts/parun','scripts/gf2poly','scripts/gatherArchives.py','scripts/qtm','scripts/waves2xmf','scripts/povgen.py',
                  'scripts/velocity2xmf','scripts/run_script_garnet','scripts/run_script_diamond',


### PR DESCRIPTION
This PR expands the error estimation and mesh adaptation capabilities to the 2D domain. Additionally, if the model/mesh is loaded via the core/apf library, the region materials can be specified explicitly with the addition of a `regList` that labels each region in the domain. Two tests are added to check these features:

- test_2DmultiRegion
- test_2DparallelLoadPUMI

These features are a subset of what's in the scorec_reconstructMesh branch and hence constitutes part 1. 