### PR TITLE
ENH: Add feature to adapt based on mesh quality checks

### DIFF
--- a/proteus/MeshAdaptPUMI/MeshAdaptPUMI.pyx
+++ b/proteus/MeshAdaptPUMI/MeshAdaptPUMI.pyx
@@ -129,3 +129,5 @@ cdef class MeshAdaptPUMI:
         errTotal=0.0;
         self.thisptr.get_local_error(errTotal)
         return errTotal
+    def getMinimumQuality(self):
+        return self.thisptr.getMinimumQuality()

--- a/proteus/MeshAdaptPUMI/SizeField.cpp
+++ b/proteus/MeshAdaptPUMI/SizeField.cpp
@@ -692,13 +692,6 @@ int MeshAdaptPUMIDrvr::getERMSizeField(double err_total)
     }
   }
 
-  //Get vtk files for fields prior to adaptation
-  if(logging_config=="on"){
-    char namebuffer[20];
-    sprintf(namebuffer,"pumi_preadapt_%i",nAdapt);
-    apf::writeVtkFiles(namebuffer, m);
-  }
-  
   //Destroy locally required fields
   apf::destroyField(size_iso_reg); 
   apf::destroyField(clipped_vtx);
@@ -716,11 +709,6 @@ int MeshAdaptPUMIDrvr::testIsotropicSizeField()
       double phi = hmin;
       clamp(phi,hmin,hmax);
       apf::setScalar(size_iso,v,0,phi);
-    }
-    char namebuffer[20];
-    if(logging_config=="on"){
-      sprintf(namebuffer,"pumi_adapt_%i",nAdapt);
-      apf::writeVtkFiles(namebuffer, m);
     }
 }
 

--- a/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
+++ b/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
@@ -312,6 +312,9 @@ int MeshAdaptPUMIDrvr::willAdapt()
   return adaptFlag;
 }
 
+#include <sam.h>
+#include <samSz.h>
+
 int MeshAdaptPUMIDrvr::adaptPUMIMesh()
 /**
  * @brief Function used to trigger adaptation
@@ -344,6 +347,9 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
       myfile.close();
     }
   }  
+  else if (size_field_config == "elementQuality"){
+    size_iso = samSz::isoSize(m);
+  }
   else if (size_field_config == "isotropic")
     testIsotropicSizeField();
   else {

--- a/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
+++ b/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
@@ -356,6 +356,12 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
     std::cerr << "unknown size field config " << size_field_config << '\n';
     abort();
   }
+  if(logging_config=="on"){
+    char namebuffer[20];
+    sprintf(namebuffer,"pumi_preadapt_%i",nAdapt);
+    apf::writeVtkFiles(namebuffer, m);
+  }
+
 
   // These are relics from an attempt to pass BCs from proteus into the error estimator.
   // They maybe useful in the future.
@@ -413,12 +419,13 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
   if(size_field_config=="ERM"){
     if (has_gBC)
       getSimmetrixBC();
-    if(logging_config=="on"){
-      char namebuffer[20];
-      sprintf(namebuffer,"pumi_postadapt_%i",nAdapt);
-      apf::writeVtkFiles(namebuffer, m);
-    }
   }
+  if(logging_config=="on"){
+    char namebuffer[20];
+    sprintf(namebuffer,"pumi_postadapt_%i",nAdapt);
+    apf::writeVtkFiles(namebuffer, m);
+  }
+
   //isReconstructed = 0; //this is needed to maintain consistency with the post-adapt conversion back to Proteus
   nAdapt++; //counter for number of adapt steps
   return 0;

--- a/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
+++ b/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
@@ -347,7 +347,7 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
       myfile.close();
     }
   }  
-  else if (size_field_config == "elementQuality"){
+  else if (size_field_config == "meshQuality"){
     size_iso = samSz::isoSize(m);
   }
   else if (size_field_config == "isotropic")
@@ -361,7 +361,6 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
     sprintf(namebuffer,"pumi_preadapt_%i",nAdapt);
     apf::writeVtkFiles(namebuffer, m);
   }
-
 
   // These are relics from an attempt to pass BCs from proteus into the error estimator.
   // They maybe useful in the future.

--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -956,6 +956,12 @@ class NS_base:  # (HasTraits):
             elif(sfConfig=='interface' ):
               adaptMeshNow=True
               logEvent("Need to Adapt")
+            elif(sfConfig=='meshQuality'):
+              minQual = p0.domain.PUMIMesh.getMinimumQuality()
+              if(minQual):
+                logEvent('The quality is %f ' % minQual)
+              adaptMeshNow=True
+              logEvent("Need to Adapt")
             else:
               adaptMeshNow=True
               logEvent("Need to Adapt")


### PR DESCRIPTION
This feature uses only IsoSizeFields to drive adaptivity which keeps the mesh effectively the same, but corrects/fixes overly skewed elements.