### PR TITLE
BLD: Remove zoltan dependency for ease of compilation

### DIFF
--- a/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
+++ b/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
@@ -379,7 +379,8 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
   else
     in = ma::configure(m, size_iso);
   ma::validateInput(in);
-  in->shouldRunPreZoltan = true;
+  in->shouldRunPreZoltan = false;
+  in->shouldRunPreParma = true;
   in->shouldRunMidParma = true;
   in->shouldRunPostParma = true;
   in->maximumImbalance = 1.05;


### PR DESCRIPTION
Zoltan, while a useful tool, is not very necessary for the adaptivity functionality. To make compilations less error prone across multiple platforms, we should move towards a stack without zoltan.