### PR TITLE
Modify logging during time step in NumericalSolution to clarify final reached time

### DIFF
--- a/proteus/NumericalSolution.py
+++ b/proteus/NumericalSolution.py
@@ -1344,6 +1344,9 @@ class NS_base:  # (HasTraits):
                     else:
                         self.firstStep=False
                         systemStepFailed=False
+                        logEvent("Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
+                                                                                              model.stepController.dt_model,
+                                                                                              model.name))
                         self.systemStepController.sequenceTaken()
                         for index,model in enumerate(self.modelList):
                             self.viewSolution(model,index)
@@ -1366,14 +1369,13 @@ class NS_base:  # (HasTraits):
                     break
                 else:
                     self.systemStepController.updateTimeHistory()
-                    self.systemStepController.choose_dt_system()
                     logEvent("Step Taken, System time step t=%12.5e, dt=%12.5e" % (self.systemStepController.t_system,
-                                                                              self.systemStepController.dt_system))
+                                                                                   self.systemStepController.dt_system))
+                    self.systemStepController.choose_dt_system()
                     if self.systemStepController.stepExact and self.systemStepController.t_system_last != self.tn:
                         self.systemStepController.stepExact_system(self.tn)
-                    logEvent("Step Taken, Model step t=%12.5e, dt=%12.5e for model %s" % (model.stepController.t_model,
-                                                                                     model.stepController.dt_model,
-                                                                                     model.name))
+                    logEvent("Potential System time step t=%12.5e, dt=%12.5e for next time step" % (self.systemStepController.t_system,
+                                                                                                    self.systemStepController.dt_system))
                 for model in self.modelList:
                     for av in self.auxiliaryVariables[model.name]:
                         av.calculate()


### PR DESCRIPTION
- Reorder two log statements during time loop to clarify the final reached time. 

- Add log statement to indicate the potential time (t) and time step size (dt) for next time step.  