### PR TITLE
removed hanging C-style comment that broke 2D Darcy terms

### DIFF
--- a/proteus/mprans/RANS2P2D.h
+++ b/proteus/mprans/RANS2P2D.h
@@ -866,7 +866,7 @@ namespace proteus
       duc_du = 0.0;
       duc_dv = 0.0;
       /* duc_dw = w/(uc+1.0e-12); */
-      /*
+
       mom_u_source += H_s*viscosity*(alpha + beta*uc)*(u-u_s);
       mom_v_source += H_s*viscosity*(alpha + beta*uc)*(v-v_s);
       /* mom_w_source += H_s*viscosity*(alpha + beta*uc)*(w-w_s); */


### PR DESCRIPTION
This came in with #525. Don't think anybody reported a bug but it breaks the wave generation and absorption zones in 2D and anything else that uses the porous medium terms.