### PR TITLE
ENH: Expose anisotropic size field options to user

### DIFF
--- a/proteus/MeshAdaptPUMI/MeshFields.cpp
+++ b/proteus/MeshAdaptPUMI/MeshFields.cpp
@@ -58,10 +58,12 @@ int MeshAdaptPUMIDrvr::transferFieldToPUMI(const char* name, double const* inArr
     assert(f);
   }
   if (!f) {
-    assert(nVar == 1 || nVar == 3);
+    assert(nVar == 1 || nVar == 3 || nVar == 9);
     int valueType;
     if (nVar == 1)
       valueType = apf::SCALAR;
+    else if(nVar == 9)
+      valueType = apf::MATRIX;
     else
       valueType = apf::VECTOR;
     f = apf::createFieldOn(m, name, valueType);

--- a/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
+++ b/proteus/MeshAdaptPUMI/cMeshAdaptPUMI.cpp
@@ -354,6 +354,11 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
     calculateSizeField();
   else if (size_field_config == "isotropicProteus")
     size_iso = m->findField("proteus_size");
+  else if (size_field_config == "anisotropicProteus"){
+      size_frame = m->findField("proteus_sizeFrame");
+      size_scale = m->findField("proteus_sizeScale");
+      adapt_type_config = "anisotropic";
+  }
   else {
     std::cerr << "unknown size field config " << size_field_config << '\n';
     abort();
@@ -394,9 +399,6 @@ int MeshAdaptPUMIDrvr::adaptPUMIMesh()
   ma::adapt(in);
   double t2 = PCU_Time();
 
-  freeField(size_iso);
-  freeField(size_frame);
-  freeField(size_scale);
   m->verify();
   double mass_after = getTotalMass();
   PCU_Add_Doubles(&mass_before,1);


### PR DESCRIPTION
Accidentally pushed initial commit onto update_adapt branch directly, so this PR simply reverts the revert commit on `update_adapt`. 

The `size_scale` (vector) and `size_frame` (matrix) fields are initialized with the option `sfConfig=anisotropicProteus` in the input file. The `size_scale` field defines the desired edge length along the direction specified by the i-th column of the `size_frame` matrix at each node. The `size_frame` matrix is currently set to be the identity matrix and the default `size_scale` field is set for the geometry of the dambreak problems such that desired length in the y-direction scales linearly with y and has no physical significance.  

Below is the initial reconstructed mesh followed by the resulting mesh post-adaptivity.

![initial_mesh_isotropic](https://user-images.githubusercontent.com/7065326/29107735-9e52a8b6-7ca9-11e7-80a8-2a35a42f96be.png)
![initial_mesh_anisotropic](https://user-images.githubusercontent.com/7065326/29107734-9e4a301e-7ca9-11e7-82bf-5be3a5d699aa.png)

 